### PR TITLE
pip generator: Generated json keys now follow a more natural order

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -9,6 +9,8 @@ import os
 import subprocess
 import tempfile
 import urllib.request
+from collections import OrderedDict
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('packages', nargs='+')
@@ -64,12 +66,12 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         '--prefix=${FLATPAK_DEST}',
     ] + opts.packages
 
-    main_module = {
-        'name': package_name,
-        'buildsystem': 'simple',
-        'build-commands': [' '.join(pip_command)],
-        'sources': []
-    }
+    main_module = OrderedDict([
+        ('name', package_name),
+        ('buildsystem', 'simple'),
+        ('build-commands', [' '.join(pip_command)]),
+        ('sources', []),
+    ])
 
     if opts.build_only:
         main_module['cleanup'] = ['*']
@@ -80,11 +82,11 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
             continue
         sha256 = get_file_hash(os.path.join(tempdir, filename))
         url = get_pypi_url(name, filename)
-        source = {
-            'type': 'file',
-            'url': url,
-            'sha256': sha256,
-        }
+        source = OrderedDict([
+            ('type', 'file'),
+            ('url', url),
+            ('sha256', sha256),
+        ])
         main_module['sources'].append(source)
 
 with open(package_name + '.json', 'w') as output:


### PR DESCRIPTION
i.e. name is at the top:

```
{
    "name": "python3-cython",
    "buildsystem": "simple",
    "build-commands": [
        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} cython"
    ],
    "sources": [
        {
            "type": "file",
            "url": "https://pypi.python.org/packages/ee/2a/c4d2cdd19c84c32d978d18e9355d1ba9982a383de87d0fcb5928553d37f4/Cython-0.27.3.tar.gz",
            "sha256": "6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64"
        }
    ]
}
```

rather than:

```
{
    "buildsystem": "simple",
    "sources": [
        {
            "url": "https://pypi.python.org/packages/ee/2a/c4d2cdd19c84c32d978d18e9355d1ba9982a383de87d0fcb5928553d37f4/Cython-0.27.3.tar.gz",
            "sha256": "6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64",
            "type": "file"
        }
    ],
    "build-commands": [
        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} cython"
    ],
    "name": "python3-cython"
}
```