### PR TITLE
npm: Support Electron on arm64

### DIFF
--- a/npm/flatpak-npm-generator.py
+++ b/npm/flatpak-npm-generator.py
@@ -13,7 +13,8 @@ import os
 electron_arches = {
     "ia32": "i386",
     "x64": "x86_64",
-    "arm": "arm"
+    "arm": "arm",
+    "arm64": "aarch64",
 }
 
 def isGitUrl(url):


### PR DESCRIPTION
Electron's 1.8 series has arm64 binaries. We should support this, since
Flathub can build them.