### PR TITLE
Add some options for flatpak-pip-generator

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -21,6 +21,8 @@ parser.add_argument('--cleanup', choices=['scripts', 'all'],
 parser.add_argument('--build-only', action='store_const',
                     dest='cleanup', const='all',
                     help='Clean up all files after build')
+parser.add_argument('--output',
+                    help='Specify output file name')
 opts = parser.parse_args()
 
 def get_pypi_url(name: str, filename: str) -> str:
@@ -94,5 +96,6 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         ])
         main_module['sources'].append(source)
 
-with open(package_name + '.json', 'w') as output:
+output_filename = opts.output or package_name + '.json'
+with open(output_filename, 'w') as output:
     output.write(json.dumps(main_module, indent=4))

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -16,8 +16,11 @@ parser = argparse.ArgumentParser()
 parser.add_argument('packages', nargs='+')
 parser.add_argument('--python2', action='store_true',
                     help='Look for a Python 2 package')
-parser.add_argument('--build-only', action='store_true',
-                    help='Cleanup files after build')
+parser.add_argument('--cleanup', choices=['scripts', 'all'],
+                    help='Select what to clean up after build')
+parser.add_argument('--build-only', action='store_const',
+                    dest='cleanup', const='all',
+                    help='Clean up all files after build')
 opts = parser.parse_args()
 
 def get_pypi_url(name: str, filename: str) -> str:
@@ -73,8 +76,10 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         ('sources', []),
     ])
 
-    if opts.build_only:
+    if opts.cleanup == 'all':
         main_module['cleanup'] = ['*']
+    elif opts.cleanup == 'scripts':
+        main_module['cleanup'] = ['/bin/*']
 
     for filename in os.listdir(tempdir):
         name = filename.rsplit('-', 1)[0]


### PR DESCRIPTION
This adds two more options to flatpak-pip-generator:
* A --cleanup option with the options of `all` or `scripts`. `all` deletes all files in the cleanup stage, `scripts` only deletes the contents of /bin. `--build-only` is now an alias for `--cleanup=all`.
* A `--output` option to explicitly specify an output file name.