### PR TITLE
pip: also clean manpages when asked to clean up scripts

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -81,7 +81,7 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
     if opts.cleanup == 'all':
         main_module['cleanup'] = ['*']
     elif opts.cleanup == 'scripts':
-        main_module['cleanup'] = ['/bin/*']
+        main_module['cleanup'] = ['/bin', '/share/man/man1']
 
     for filename in os.listdir(tempdir):
         name = filename.rsplit('-', 1)[0]


### PR DESCRIPTION
After deleting the scripts, there's no point to keeping around any manpages that may have been installed for said scripts.