### PR TITLE
npm: Fix URL generation

### DIFF
--- a/npm/flatpak-npm-generator.py
+++ b/npm/flatpak-npm-generator.py
@@ -36,7 +36,7 @@ def parseGitUrl(url):
             "sed -i 's^\"github:" + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
-            "^g' package.json")
+            "\"^g' package.json")
 
     elif url.startswith("gitlab:"):
         prefixStrippedUrl = re.split("gitlab:", url)[1]
@@ -46,7 +46,7 @@ def parseGitUrl(url):
             "sed -i 's^\"gitlab:" + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
-            "^g' package.json")
+            "\"^g' package.json")
 
     elif url.startswith("bitbucket:"):
         prefixStrippedUrl = re.split("bitbucket:", url)[1]
@@ -56,7 +56,7 @@ def parseGitUrl(url):
             "sed -i 's^\"bitbucket:" + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
-            "^g' package.json")
+            "\"^g' package.json")
 
     elif url.startswith("git://"):
         prefixStrippedUrl = re.split(r'\w+\.\w+\/',url)[1]
@@ -67,7 +67,7 @@ def parseGitUrl(url):
             "sed -i 's^\"git://" + domain + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
-            "^g' package.json")
+            "\"^g' package.json")
 
     elif url.startswith("git+https://"):
         prefixStrippedUrl = re.split(r'\w+\.\w+\/',url)[1]
@@ -78,7 +78,7 @@ def parseGitUrl(url):
             "sed -i 's^\"git+https://" + domain + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
-            "^g' package.json")
+            "\"^g' package.json")
 
     elif url.startswith("git+http://"):
         prefixStrippedUrl = re.split(r'\w+\.\w+\/',url)[1]
@@ -89,7 +89,7 @@ def parseGitUrl(url):
             "sed -i 's^\"git+http://" + domain + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
-            "^g' package.json")
+            "\"^g' package.json")
 
     elif url.startswith("git+ssh://"):
         print("ssh protocol not supported")

--- a/npm/flatpak-npm-generator.py
+++ b/npm/flatpak-npm-generator.py
@@ -33,8 +33,8 @@ def parseGitUrl(url):
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         parsedUrl["url"] = "https://github.com/" + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"github:" + parsedUrl["path"] +
-            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            "sed -r -i 's^\"github:" + parsedUrl["path"] +
+            "(#.*)?\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "\"^g' package.json")
 
@@ -43,8 +43,8 @@ def parseGitUrl(url):
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         parsedUrl["url"] = "https://gitlab.com/" + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"gitlab:" + parsedUrl["path"] +
-            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            "sed -r -i 's^\"gitlab:" + parsedUrl["path"] +
+            "(#.*)?\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "\"^g' package.json")
 
@@ -53,8 +53,8 @@ def parseGitUrl(url):
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         parsedUrl["url"] = "https://bitbucket.org/" + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"bitbucket:" + parsedUrl["path"] +
-            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            "sed -r -i 's^\"bitbucket:" + parsedUrl["path"] +
+            "(#.*)?\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "\"^g' package.json")
 
@@ -64,8 +64,8 @@ def parseGitUrl(url):
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "git://" + domain + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"git://" + domain + parsedUrl["path"] +
-            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            "sed -r -i 's^\"git://" + domain + parsedUrl["path"] +
+            "(#.*)?\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "\"^g' package.json")
 
@@ -75,8 +75,8 @@ def parseGitUrl(url):
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "https://" + domain + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"git+https://" + domain + parsedUrl["path"] +
-            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            "sed -r -i 's^\"git+https://" + domain + parsedUrl["path"] +
+            "(#.*)?\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "\"^g' package.json")
 
@@ -86,8 +86,8 @@ def parseGitUrl(url):
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "http://" + domain + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"git+http://" + domain + parsedUrl["path"] +
-            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            "sed -r -i 's^\"git+http://" + domain + parsedUrl["path"] +
+            "(#.*)?\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "\"^g' package.json")
 

--- a/npm/flatpak-npm-generator.py
+++ b/npm/flatpak-npm-generator.py
@@ -32,40 +32,66 @@ def parseGitUrl(url):
         prefixStrippedUrl = re.split("github:", url)[1]
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         parsedUrl["url"] = "https://github.com/" + parsedUrl["path"]
-        parsedUrl["sedCommand"] = "sed -i 's^\"github:" + parsedUrl["path"] + "#" + ".*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" + parsedUrl["name"] + "\#"+parsedUrl["commit"]+"^g' package.json"
+        parsedUrl["sedCommand"] = (
+            "sed -i 's^\"github:" + parsedUrl["path"] +
+            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
+            "^g' package.json")
 
     elif url.startswith("gitlab:"):
         prefixStrippedUrl = re.split("gitlab:", url)[1]
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         parsedUrl["url"] = "https://gitlab.com/" + parsedUrl["path"]
-        parsedUrl["sedCommand"] = "sed -i 's^\"gitlab:" + parsedUrl["path"] + "#" + ".*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" + parsedUrl["name"] + "\#"+parsedUrl["commit"]+"^g' package.json"
+        parsedUrl["sedCommand"] = (
+            "sed -i 's^\"gitlab:" + parsedUrl["path"] +
+            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
+            "^g' package.json")
 
     elif url.startswith("bitbucket:"):
         prefixStrippedUrl = re.split("bitbucket:", url)[1]
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         parsedUrl["url"] = "https://bitbucket.org/" + parsedUrl["path"]
-        parsedUrl["sedCommand"] = "sed -i 's^\"bitbucket:" + parsedUrl["path"] + "#" + ".*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" + parsedUrl["name"] + "\#"+parsedUrl["commit"]+"^g' package.json"
+        parsedUrl["sedCommand"] = (
+            "sed -i 's^\"bitbucket:" + parsedUrl["path"] +
+            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
+            "^g' package.json")
 
     elif url.startswith("git://"):
         prefixStrippedUrl = re.split(r'\w+\.\w+\/',url)[1]
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "git://" + domain + parsedUrl["path"]
-        parsedUrl["sedCommand"] = "sed -i 's^\"git://" + parsedUrl["domain"] + parsedUrl["path"] + "#" + ".*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" + parsedUrl["name"] + "\#"+parsedUrl["commit"]+"^g' package.json"
+        parsedUrl["sedCommand"] = (
+            "sed -i 's^\"git://" + parsedUrl["domain"] + parsedUrl["path"] +
+            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
+            "^g' package.json")
 
     elif url.startswith("git+https://"):
         prefixStrippedUrl = re.split(r'\w+\.\w+\/',url)[1]
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "https://" + domain + parsedUrl["path"]
-        parsedUrl["sedCommand"] = "sed -i 's^\"git+https://" + parsedUrl["domain"] + parsedUrl["path"] + "#" + ".*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" + parsedUrl["name"] + "\#"+parsedUrl["commit"]+"^g' package.json"
+        parsedUrl["sedCommand"] = (
+            "sed -i 's^\"git+https://" + parsedUrl["domain"] +
+            parsedUrl["path"] +
+            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
+            "^g' package.json")
 
     elif url.startswith("git+http://"):
         prefixStrippedUrl = re.split(r'\w+\.\w+\/',url)[1]
         parsedUrl = getPathandCommitInfo(prefixStrippedUrl)
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "http://" + domain + parsedUrl["path"]
-        parsedUrl["sedCommand"] = "sed -i 's^\"git+http://" + parsedUrl["domain"] + parsedUrl["path"] + "#" + ".*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" + parsedUrl["name"] + "\#"+parsedUrl["commit"]+"^g' package.json"
+        parsedUrl["sedCommand"] = (
+            "sed -i 's^\"git+http://" + parsedUrl["domain"] +
+            parsedUrl["path"] +
+            "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
+            parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
+            "^g' package.json")
 
     elif url.startswith("git+ssh://"):
         print("ssh protocol not supported")

--- a/npm/flatpak-npm-generator.py
+++ b/npm/flatpak-npm-generator.py
@@ -64,7 +64,7 @@ def parseGitUrl(url):
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "git://" + domain + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"git://" + parsedUrl["domain"] + parsedUrl["path"] +
+            "sed -i 's^\"git://" + domain + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "^g' package.json")
@@ -75,8 +75,7 @@ def parseGitUrl(url):
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "https://" + domain + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"git+https://" + parsedUrl["domain"] +
-            parsedUrl["path"] +
+            "sed -i 's^\"git+https://" + domain + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "^g' package.json")
@@ -87,8 +86,7 @@ def parseGitUrl(url):
         domain = re.findall(r'\w+\.\w+\/',url)[0]
         parsedUrl["url"] = "http://" + domain + parsedUrl["path"]
         parsedUrl["sedCommand"] = (
-            "sed -i 's^\"git+http://" + parsedUrl["domain"] +
-            parsedUrl["path"] +
+            "sed -i 's^\"git+http://" + domain + parsedUrl["path"] +
             "#.*\"^\"git+file:/var/tmp/build-dir/npm-cache/git/" +
             parsedUrl["name"] + "\\#" + parsedUrl["commit"] +
             "^g' package.json")


### PR DESCRIPTION
There was an inconsistency when switching to the 'domain' variable, as
some code still used the 'parsedUrl["domain"]' value which didn't exist
any longer. This made flatpak-npm-generator broken for some
package-lock.json files.