### PR TITLE
npm: Remove "from" keys in package-lock.json

### DIFF
--- a/npm/flatpak-npm-generator.py
+++ b/npm/flatpak-npm-generator.py
@@ -148,8 +148,15 @@ def getModuleSources(module, name, seen=None, include_devel=True, npm3=False):
         }
         sources.append(source)
         parsedUrl["sedCommandLock"] = "sed -i 's^" + module["version"] + "^git+file:/var/tmp/build-dir/" + subdir + "#" + parsedUrl["commit"] + "^g' package-lock.json"
+
+        parsedFromUrl = getPathandCommitInfo(module["version"])
+        parsedUrl["sedCommandFrom"] = (
+            "sed -i 's^\"from\": \"" + parsedFromUrl["path"] +
+            "\",^^g' package-lock.json")
+
         patches.append(parsedUrl["sedCommand"])
         patches.append(parsedUrl["sedCommandLock"])
+        patches.append(parsedUrl["sedCommandFrom"])
 
     if added_url:
         # Special case electron, adding sources for the electron binaries


### PR DESCRIPTION
Newer package-lock.jsons have a "from" key pointing to the original
repository. This needs to be deleted, or else npm will still try to go
to the network during the build.