### PR TITLE
pip: handle spaces in package names

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -9,6 +9,7 @@ import os
 import subprocess
 import tempfile
 import urllib.request
+import shlex
 from collections import OrderedDict
 
 
@@ -79,7 +80,10 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         '--no-index',
         '--find-links="file://${PWD}"',
         pip_install_prefix,
-    ] + opts.packages
+    ] + [
+        shlex.quote(package)
+        for package in opts.packages
+    ]
 
     main_module = OrderedDict([
         ('name', package_name),


### PR DESCRIPTION
If you want to generate a manifest for diffoscope, including its
optional distro_detection and cmdline components. This invocation
correctly fetches the list of necessary packages:

    flatpak-pip-generator 'diffoscope[distro_detection, cmdline]'

But in the resulting file, the 'build-commands' line is not properly
quoted, so 'diffoscope[distro_detection,' and 'cmdline]' are passed as
separate arguments to 'pip3 install', and the build fails.

Fix this by shell-quoting arguments using shlex.quote().

https://github.com/flathub/flathub/pull/698