### PR TITLE
Add flatpak-node-generator

### DIFF
--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,0 +1,1 @@
+.mypy_cache/

--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,1 +1,3 @@
 .mypy_cache/
+.flatpak-builder/
+_build/

--- a/node/README.md
+++ b/node/README.md
@@ -1,3 +1,130 @@
 # flatpak-node-generator
 
 A more modern successor for flatpak-npm-generator and flatpak-yarn-generator.
+
+## Requirements
+
+- Python 3.6+.
+- aiohttp. (flatpak-node-generator will fall back onto urllib.request if aiohttp is not available,
+  but performance will take a serious hit.)
+
+## Complete examples
+
+There are two examples provided for how to use flatpak-node-generator:
+
+- `vanilla-quick-start` - A Flatpak of
+  [electron-quick-start](https://github.com/electron/electron-quick-start). It uses npm for
+  package management and a rather basic Electron workflow.
+  (Current on the Electron 4 version.)
+- `webpack-quick-start` - A Flatpak of
+  [electron-webpack-quick-start](https://github.com/electron-userland/electron-webpack-quick-start).
+  It uses yarn for package management and electron-builder + webpack.
+
+Both manifests have comments to highlight their differences, so you can mix and match to e.g.
+get npm with electron-builder.
+
+## Usage
+
+```
+usage: flatpak-node-generator.py [-h] [-o OUTPUT] [-r] [-R RECURSIVE_PATTERN]
+                                 [--no-devel] [--no-index] [--no-aiohttp]
+                                 [--retries RETRIES] [-P]
+                                 {npm,yarn} lockfile
+
+Flatpak Node generator
+
+positional arguments:
+  {npm,yarn}
+  lockfile              The lockfile path (package-lock.json or yarn.lock)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTPUT, --output OUTPUT
+                        The output sources file
+  -r, --recursive       Recursively process all files under the lockfile
+                        directory with the lockfile basename
+  -R RECURSIVE_PATTERN, --recursive-pattern RECURSIVE_PATTERN
+                        Given -r, restrict files to those matching the given
+                        pattern.
+  --no-devel            Don't include devel dependencies (npm only)
+  --no-aiohttp          Don't use aiohttp, and silence any warnings related to
+                        it
+  --retries RETRIES     Number of retries of failed requests
+  -P, --no-autopatch    Don't automatically patch Git sources from
+                        package*.json
+```
+
+flatpak-node-generator.py takes the package manager (npm or yarn), and a path to a lockfile for
+that package manager. It will then write an output sources file (default is generated-sources.json)
+containing all the sources set up like needed for the given package manager.
+
+If you're on npm and you don't want to include devel dependencies, pass --no-devel, and pass
+--production to `npm install` itself when you call.
+
+### Recursive mode
+
+Sometimes you might have multiple lockfiles in a single source tree that need to have sources
+generated for them. For this, you can pass `-r`, which will find all the lockfiles with the
+name of the lockfile path you gave it in the same directory.
+
+E.g. for instance, if you run:
+
+```
+flatpak-node-generator yarn -r ~/my-project/yarn.lock
+```
+
+flatpak-node-generator will find all files named yarn.lock inside of my-project.
+
+If you want to match only certain lockfiles, pass `-R pattern` too:
+
+```
+flatpak-node-generator yarn -r ~/my-project/yarn.lock -R 'something*/yarn.lock' -R 'another*/yarn.lock'
+```
+
+In this case, only lockfiles matching `something*/yarn.lock` or `another*/yarn.lock` will be used.
+
+With yarn, we're done here. However, npm has a few more curveballs you need to know about.
+
+If you have any Git sources in your package.json, then they need to be patched to point to the
+Flatpak-downloaded Git repos. flatpak-node-generator normally takes care of this patching
+automatically. However, in the case of recursive package.jsons, this is a little different.
+
+Say you have the following project directory structure:
+
+```
+my-project/
+  node_modules/
+    my-nested-project/
+      package.json
+      package-lock.json
+  package-lock.json
+```
+
+`my-nested-project` doesn't ship built dependencies, so you need to build them yourself.
+Therefore, you might run something like this in your Flatpak build commands:
+
+- `npm install ...` in the root directory.
+- `npm install ...` in the my-nested-project directory.
+- `npm run build` or whatever build command in the my-nested-project directory.
+
+However, if my-nested-project uses a Git source, then flatpak-node-generator will try to patch
+it out...except my-nested-project's directory won't exist until you run the first `npm install`,
+therefore the patch command and your build will fail.
+
+In order to work around this, you need to pass `-P` / `--no-autopatch` to flatpak-node-generator.
+This will disable the automated patching. Then, you'll need to call the scripts to patch your
+package files manually. so a new build-commands might look like this:
+
+- `flatpak-node/patch.sh`.
+- `npm install ...` in the root directory.
+- `flatpak-node/patch/node_modules/my-nested-project.sh`
+- `npm install ...` in the my-nested-project directory.
+- `npm run build` or whatever build command in the my-nested-project directory.
+
+In short, flatpak-node-generator will generate a patch script named
+`flatpak-node/patch/path-to-package-lock.json`; if package-lock.json is in the root directory,
+then the name will just be `patch.sh`. Here these will be called manually, thereby ensuring
+that the files that need to be patched will already exist.
+
+(In addition, flatpak-node-generator will generate `flatpak-node/patch-all.sh`, which is what is
+automatically run by default when you *don't* pass `-P`.)

--- a/node/README.md
+++ b/node/README.md
@@ -1,6 +1,7 @@
 # flatpak-node-generator
 
-A more modern successor for flatpak-npm-generator and flatpak-yarn-generator.
+A more modern successor for flatpak-npm-generator and flatpak-yarn-generator, for Node 10+ only.
+(For Node 8, use flatpak-npm-generator and flatpak-yarn-generator.)
 
 ## Requirements
 

--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,3 @@
+# flatpak-node-generator
+
+A more modern successor for flatpak-npm-generator and flatpak-yarn-generator.

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -831,8 +831,6 @@ async def main() -> None:
                         help='Given -r, restrict files to those matching the given pattern.')
     parser.add_argument('--no-devel', action='store_true',
                         help="Don't include devel dependencies (npm only)")
-    parser.add_argument('--no-index', action='store_true',
-                        help='Skip building the cacache index (npm only)')
     parser.add_argument('--no-aiohttp', action='store_true',
                         help="Don't use aiohttp, and silence any warnings related to it")
     parser.add_argument('--retries', type=int, help='Number of retries of failed requests',
@@ -847,7 +845,7 @@ async def main() -> None:
     Requests.retries = args.retries
 
     if args.type == 'yarn' and (args.no_devel or args.no_autopatch):
-        sys.exit('--no-devel and --no-index do not apply to Yarn.')
+        sys.exit('--no-devel and --no-autopatch do not apply to Yarn.')
 
     if args.stub_requests:
         Requests.instance = StubRequests()

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -611,7 +611,8 @@ class NpmModuleProvider(ModuleProvider, SpecialSourceProviderMixin):
         self.gen.add_script_source(patch_all_commands, patch_all_dest)
 
         if not self.no_autopatch:
-            self.gen.add_command(f'bash {patch_all_dest}')
+            # FLATPAK_BUILDER_BUILDDIR isn't defined yet for script sources.
+            self.gen.add_command(f'FLATPAK_BUILDER_BUILDDIR=$PWD {patch_all_dest}')
 
         if self.index_entries:
             # (ab-)use a "script" module to generate the index.

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -199,6 +199,17 @@ class RemoteUrlMetadata(NamedTuple):
         return size
 
 
+class Semver(NamedTuple):
+    major: int
+    minor: int
+    patch: int
+
+    @staticmethod
+    def parse(version: str) -> 'Semver':
+        major, minor, patch = map(int, version.split('.'))
+        return Semver(major, minor, patch)
+
+
 class ResolvedSource(NamedTuple):
     resolved: str
     integrity: Optional[Integrity]
@@ -355,9 +366,8 @@ class SpecialSourceProviderMixin:
 
     def _get_chromedriver_binary_dir(self, gen: ManifestGenerator, chromedriver_version: str,
                                      package: Package) -> Path:
-        major, minor, _ = package.version.split('.')
         tmp_root = gen.tmp_root
-        if int(major) > 2 or int(minor) >= 46:
+        if Semver.parse(package.version) >= Semver(2, 46, 0):
             tmp_root /= chromedriver_version
 
         return tmp_root / 'chromedriver'

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -721,8 +721,12 @@ class YarnModuleProvider(ModuleProvider, SpecialSourceProviderMixin):
         assert isinstance(source, ResolvedSource)
 
         integrity = await source.retrieve_integrity()
+
         url_parts = urllib.parse.urlparse(source.resolved)
-        destination = self.mirror_dir / os.path.basename(url_parts.path)
+        extension = os.path.splitext(url_parts.path)[1]
+
+        escaped_name = package.name.replace('/', '-')
+        destination = self.mirror_dir / f'{escaped_name}-{package.version}{extension}'
 
         self.gen.add_url_source(source.resolved, integrity, destination)
 

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -13,8 +13,6 @@ import binascii
 import collections
 import contextlib
 import hashlib
-import io
-import itertools
 import json
 import os
 import re
@@ -52,7 +50,7 @@ class Requests:
                     yield part
 
                 return
-            except:
+            except Exception:
                 if i == Requests.retries:
                     raise
 
@@ -60,7 +58,7 @@ class Requests:
         for i in range(1, Requests.retries + 1):
             try:
                 return await self._read_all(url)
-            except:
+            except Exception:
                 if i == Requests.retries:
                     raise
 

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+
+__license__ = 'MIT'
+
+from typing import *
+
+from pathlib import Path
+
+import argparse
+import asyncio
+import base64
+import binascii
+import collections
+import contextlib
+import hashlib
+import io
+import itertools
+import json
+import os
+import shlex
+import shutil
+import sys
+import textwrap
+import urllib.parse
+import urllib.request
+
+
+class Requests:
+    instance: 'Requests'
+
+    DEFAULT_PART_SIZE = 4096
+
+    @property
+    def is_async(self) -> bool:
+        raise NotImplementedError
+
+    async def read_parts(self, url: str, size: int = DEFAULT_PART_SIZE) -> AsyncIterator[bytes]:
+        raise NotImplementedError
+        yield b''  # Silence mypy.
+
+    async def read_all(self, url: str) -> bytes:
+        raise NotImplementedError
+
+
+class UrllibRequests(Requests):
+    @property
+    def is_async(self) -> bool:
+        return False
+
+    async def read_parts(self, url: str,
+                         size: int = Requests.DEFAULT_PART_SIZE) -> AsyncIterator[bytes]:
+        with urllib.request.urlopen(url) as response:
+            while True:
+                data = response.read(size)
+                if not data:
+                    return
+
+                yield data
+
+    async def read_all(self, url: str) -> bytes:
+        with urllib.request.urlopen(url) as response:
+            return response.read()
+
+
+class StubRequests(Requests):
+    @property
+    def is_async(self) -> bool:
+        return True
+
+    async def read_parts(self, url: str,
+                         size: int = Requests.DEFAULT_PART_SIZE) -> AsyncIterator[bytes]:
+        yield b''
+
+    async def read_all(self, url: str) -> bytes:
+        return b''
+
+
+Requests.instance = UrllibRequests()
+
+
+try:
+    import aiohttp
+
+    class AsyncRequests(Requests):
+        @property
+        def is_async(self) -> bool:
+            return True
+
+        @contextlib.asynccontextmanager
+        async def _open_stream(self, url: str) -> AsyncIterator[aiohttp.StreamReader]:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url) as response:
+                    yield response.content
+
+        async def read_parts(self, url: str,
+                             size: int = Requests.DEFAULT_PART_SIZE) -> AsyncIterator[bytes]:
+            async with self._open_stream(url) as stream:
+                while True:
+                    data = await stream.read(size)
+                    if not data:
+                        return
+
+                    yield data
+
+        async def read_all(self, url: str) -> bytes:
+            async with self._open_stream(url) as stream:
+                return await stream.read()
+
+    Requests.instance = AsyncRequests()
+
+except ImportError:
+    pass
+
+
+class Integrity(NamedTuple):
+    algorithm: str
+    digest: str
+
+    @staticmethod
+    def parse(value: str) -> 'Integrity':
+        algorithm, encoded_digest = value.split('-', 1)
+        assert algorithm.startswith('sha'), algorithm
+        digest = binascii.hexlify(base64.b64decode(encoded_digest)).decode()
+
+        return Integrity(algorithm, digest)
+
+    @staticmethod
+    def generate(data: AnyStr, *, algorithm: str = 'sha256') -> 'Integrity':
+        builder = IntegrityBuilder(algorithm)
+        builder.update(data)
+        return builder.build()
+
+    def to_base64(self) -> str:
+        return base64.b64encode(binascii.unhexlify(self.digest)).decode()
+
+
+class IntegrityBuilder:
+    def __init__(self, algorithm: str = 'sha256') -> None:
+        self.algorithm = algorithm
+        self._hasher = hashlib.new(algorithm)
+
+    def update(self, data: AnyStr) -> None:
+        data_bytes: bytes
+        if isinstance(data, str):
+            data_bytes = data.encode()
+        else:
+            data_bytes = data
+        self._hasher.update(data_bytes)
+
+    def build(self) -> Integrity:
+        return Integrity(algorithm=self.algorithm, digest=self._hasher.hexdigest())
+
+
+class RemoteUrlMetadata(NamedTuple):
+    integrity: Integrity
+    size: int
+
+    @staticmethod
+    async def get(url: str, *, integrity_algorithm: str = 'sha256') -> 'RemoteUrlMetadata':
+        builder = IntegrityBuilder(integrity_algorithm)
+        size = 0
+
+        async for part in Requests.instance.read_parts(url):
+            builder.update(part)
+            size += len(part)
+
+        return RemoteUrlMetadata(integrity=builder.build(), size=size)
+
+    @staticmethod
+    async def get_size(url: str) -> int:
+        size = 0
+        async for part in Requests.instance.read_parts(url):
+            size += len(part)
+        return size
+
+
+class ResolvedSource(NamedTuple):
+    resolved: str
+    integrity: Optional[Integrity]
+
+    async def retrieve_integrity(self) -> Integrity:
+        if self.integrity is not None:
+            return self.integrity
+        else:
+            metadata = await RemoteUrlMetadata.get(self.resolved)
+            return metadata.integrity
+
+
+class GitSource(NamedTuple):
+    original: str
+    url: str
+    commit: str
+    from_: str
+
+
+PackageSource = Union[ResolvedSource, GitSource]
+
+
+class Package(NamedTuple):
+    name: str
+    version: str
+    source: PackageSource
+    lockfile: Path
+
+
+class ManifestGenerator(contextlib.AbstractContextManager):
+    def __init__(self) -> None:
+        # Store the dicts as a "set" of tuples, then rebuild the dict when returning it.
+        # That way, we ensure uniqueness.
+        # We can't actually use a set because it loses insertion order though, so we use a
+        # dict (which preserves the order on Python 3.6+).
+        self._sources: Dict[Tuple[Tuple[str, Any], ...], None] = {}
+        self._commands: List[str] = []
+
+    def __exit__(self, *_: Any) -> None:
+        self._finalize()
+
+    @property
+    def data_root(self) -> Path:
+        return Path('flatpak-node')
+
+    @property
+    def sources(self) -> List[Dict]:
+        return list(map(dict, self._sources.keys()))  # type: ignore
+
+    def _add_source(self, source: Dict[str, Any]) -> None:
+        self._sources[tuple(source.items())] = None
+
+    def _add_source_with_destination(self, source: Dict[str, Any],
+                                     destination: Optional[Path], *, is_dir: bool) -> None:
+        if destination is not None:
+            if is_dir:
+                source['dest'] = str(destination)
+            else:
+                source['dest-filename'] = destination.name
+                if len(destination.parts) > 1:
+                    source['dest'] = str(destination.parent)
+
+        self._add_source(source)
+
+    def add_url_source(self, url: str, integrity: Integrity, destination: Optional[Path] = None,
+                       *, only_arches: Optional[List[str]] = None) -> None:
+        source: Dict[str, Any] = {'type': 'file', 'url': url,
+                                  integrity.algorithm: integrity.digest}
+        if only_arches:
+            source['only-arches'] = tuple(only_arches)
+        self._add_source_with_destination(source, destination, is_dir=False)
+
+    def add_data_source(self, data: AnyStr, destination: Path) -> None:
+        source = {'type': 'file', 'url': 'data:' + urllib.parse.quote(data)}
+        self._add_source_with_destination(source, destination, is_dir=False)
+
+    def add_git_source(self, url: str, commit: str, destination: Optional[Path] = None) -> None:
+        source = {'type': 'git', 'url': url, 'commit': commit}
+        self._add_source_with_destination(source, destination, is_dir=True)
+
+    def add_script_source(self, commands: List[str], destination: Path) -> None:
+        source = {'type': 'script', 'commands': tuple(commands)}
+        self._add_source_with_destination(source, destination, is_dir=False)
+
+    def add_command(self, command: str) -> None:
+        self._commands.append(command)
+
+    def _finalize(self) -> None:
+        if self._commands:
+            self._add_source({'type': 'shell', 'commands': tuple(self._commands)})
+
+
+class LockfileProvider:
+    def process_lockfile(self, lockfile: Path) -> Iterable[Package]:
+        raise NotImplementedError()
+
+
+class ModuleProvider(contextlib.AbstractContextManager):
+    async def generate_package(self, package: Package) -> None:
+        raise NotImplementedError()
+
+
+class ElectronModuleProviderMixin:
+    async def _parse_electron_asset_integrities(self, data: str) -> Dict[str, Integrity]:
+        result: Dict[str, Integrity] = {}
+
+        for line in data.splitlines():
+            digest, star_filename = line.split()
+            filename = star_filename.strip('*')
+            result[filename] = Integrity(algorithm='sha256', digest=digest)
+
+        return result
+
+    async def generate_electron_modules(self, gen: ManifestGenerator, package: Package) -> None:
+        if isinstance(Requests.instance, StubRequests):
+            # This is going to crash and burn.
+            return
+
+        base_url = f'https://github.com/electron/electron/releases/download/v{package.version}'
+        integrity_url = f'{base_url}/SHASUMS256.txt'
+        integrity_data = (await Requests.instance.read_all(integrity_url)).decode()
+        integrities = await self._parse_electron_asset_integrities(integrity_data)
+
+        electron_cache_dir = gen.data_root / 'electron-cache'
+
+        electron_arches_to_flatpak = {
+            'ia32': 'i386',
+            'x64': 'x86_64',
+            'armv7l': 'arm',
+            'arm64': 'aarch64',
+        }
+
+        for electron_arch, flatpak_arch in electron_arches_to_flatpak.items():
+            binary_filename = f'electron-v{package.version}-linux-{electron_arch}.zip'
+            binary_url = f'{base_url}/{binary_filename}'
+            integrity = integrities[binary_filename]
+            destination = electron_cache_dir / binary_filename
+
+            gen.add_url_source(binary_url, integrity, destination, only_arches=[flatpak_arch])
+
+        integrity = Integrity.generate(integrity_data)
+        destination = electron_cache_dir / f'SHASUMS256.txt-{package.version}'
+        gen.add_url_source(integrity_url, integrity, destination)
+
+
+class NpmLockfileProvider(LockfileProvider):
+    def __init__(self, no_devel: bool):
+        self.no_devel = no_devel
+
+    def parse_git_source(self, version: str, from_: str) -> Optional[GitSource]:
+        git_prefixes = {
+            'github': 'https://github.com/',
+            'gitlab': 'https://gitlab.com/',
+            'bitbucket': 'https://bitbucket.com/',
+            'git': 'git://',
+            'git+http': 'http://',
+            'git+https': 'https://',
+        }
+
+        assert version.count('#') == 1, version
+        original, commit = version.split('#')
+
+        url: Optional[str] = None
+
+        for npm_prefix, url_prefix in git_prefixes.items():
+            if original.startswith(npm_prefix + ':'):
+                url = url_prefix + original[len(npm_prefix)+1:]
+                break
+        else:
+            return None
+
+        return GitSource(original=original, url=url, commit=commit, from_=from_)
+
+    def process_dependencies(self, lockfile: Path,
+                             dependencies: Dict[str, Dict]) -> Iterable[Package]:
+        for name, info in dependencies.items():
+            if info.get('dev') and self.no_devel:
+                continue
+            elif info.get('bundled'):
+                continue
+
+            version: str = info['version']
+
+            source: PackageSource
+            if info.get('resolved'):
+                source = ResolvedSource(resolved=info['resolved'],
+                                        integrity=Integrity.parse(info['integrity']))
+            else:
+                git_source = self.parse_git_source(version, info['from'])
+                assert git_source is not None, f'{name} is neither resolved nor a git version'
+                source = git_source
+
+            yield Package(name=name, version=version, source=source, lockfile=lockfile)
+
+            if 'dependencies' in info:
+                yield from self.process_dependencies(lockfile, info['dependencies'])
+
+    def process_lockfile(self, lockfile: Path) -> Iterable[Package]:
+        with open(lockfile) as fp:
+            data = json.load(fp)
+
+        assert data['lockfileVersion'] == 1, data['lockfileVersion']
+
+        yield from self.process_dependencies(lockfile, data['dependencies'])
+
+
+class NpmModuleProvider(ModuleProvider, ElectronModuleProviderMixin):
+    def __init__(self, gen: ManifestGenerator, lockfile_root: Path, no_index: bool):
+        self.gen = gen
+        self.lockfile_root = lockfile_root
+        self.no_index = no_index
+        self.npm_cache_dir = self.gen.data_root / 'npm-cache'
+        self.cacache_dir = self.npm_cache_dir / '_cacache'
+        self.seen_registry_data: Set[str] = set()
+        self.index_entries: Dict[Path, str] = {}
+        self.all_lockfiles: Set[Path] = set()
+        # Mapping of lockfiles to a dict of the Git source target paths and GitSource objects.
+        self.git_sources: DefaultDict[Path, Dict[Path, GitSource]] = collections.defaultdict(
+            lambda: {})
+
+    def __exit__(self, *_: Any) -> None:
+        self._finalize()
+
+    def get_cacache_integrity_path(self, integrity: Integrity) -> Path:
+        digest = integrity.digest
+        return Path(digest[0:2]) / digest[2:4] / digest[4:]
+
+    def get_cacache_index_path(self, integrity: Integrity) -> Path:
+        return self.cacache_dir / Path('index-v5') / self.get_cacache_integrity_path(integrity)
+
+    def get_cacache_content_path(self, integrity: Integrity) -> Path:
+        return (self.cacache_dir / Path('content-v2') / integrity.algorithm /
+                self.get_cacache_integrity_path(integrity))
+
+    def add_index_entry(self, url: str, metadata: RemoteUrlMetadata) -> None:
+        if not self.no_index:
+            key = f'make-fetch-happen:request-cache:{url}'
+            index_json = json.dumps({
+                'key': key,
+                'integrity': f'{metadata.integrity.algorithm}-{metadata.integrity.to_base64()}',
+                'time': 0,
+                'size': metadata.size,
+                'metadata': {
+                    'url': url,
+                    'reqHeaders': {},
+                    'resHeaders': {},
+                },
+            })
+
+            content_integrity = Integrity.generate(index_json, algorithm='sha1')
+            index = '\t'.join((content_integrity.digest, index_json))
+
+            key_integrity = Integrity.generate(key)
+            index_path = self.get_cacache_index_path(key_integrity)
+            self.index_entries[index_path] = index
+
+    async def add_npm_registry_data(self, package_url: str) -> None:
+        data_url = package_url.split('/-/')[0]
+        if data_url in self.seen_registry_data:
+            # These results are going to be the same each time.
+            return
+
+        data = await Requests.instance.read_all(data_url)
+        metadata = RemoteUrlMetadata(integrity=Integrity.generate(data), size=len(data))
+        content_path = self.get_cacache_content_path(metadata.integrity)
+        self.gen.add_data_source(data, content_path)
+        self.add_index_entry(data_url, metadata)
+        self.seen_registry_data.add(data_url)
+
+    async def generate_package(self, package: Package) -> None:
+        self.all_lockfiles.add(package.lockfile)
+        source = package.source
+
+        if isinstance(source, ResolvedSource):
+            integrity = await source.retrieve_integrity()
+            size = await RemoteUrlMetadata.get_size(source.resolved)
+            metadata = RemoteUrlMetadata(integrity=integrity, size=size)
+            content_path = self.get_cacache_content_path(integrity)
+            self.gen.add_url_source(source.resolved, integrity, content_path)
+            self.add_index_entry(source.resolved, metadata)
+
+            # XXX: This probably is not generic enough.
+            if 'registry.npmjs.org' in source.resolved:
+                await self.add_npm_registry_data(source.resolved)
+
+            if package.name == 'electron':
+                await self.generate_electron_modules(self.gen, package)
+
+        elif isinstance(source, GitSource):
+            # Get a unique name to use for the Git repository folder.
+            name = f'{package.name}-{source.commit}'
+            path = self.gen.data_root / 'git-packages' / name
+            self.git_sources[package.lockfile][path] = source
+            self.gen.add_git_source(source.url, source.commit, path)
+
+    def relative_lockfile_dir(self, lockfile: Path) -> Path:
+        return lockfile.parent.relative_to(self.lockfile_root)
+
+    def _finalize(self) -> None:
+        init_commands: DefaultDict[Path, List[str]] = collections.defaultdict(lambda: [])
+
+        if self.git_sources:
+            # Generate jq scripts to patch the package*.json files.
+            scripts = {
+                'package.json': '''
+                    walk(
+                        if type == "object"
+                        then
+                            to_entries | map(
+                                if (.value | type == "string") and $data[.value]
+                                then .value = "git+file:\($buildroot)/\($data[.value])"
+                                else .
+                                end
+                            ) | from_entries
+                        else .
+                        end
+                    )
+                ''',
+                'package-lock.json': '''
+                    walk(
+                        if type == "object" and (.version | type == "string") and $data[.version]
+                        then
+                            .version = "git+file:\($buildroot)/\($data[.version])"
+                        else .
+                        end
+                    )
+                ''',
+            }
+
+            for lockfile, sources in self.git_sources.items():
+                prefix = self.relative_lockfile_dir(lockfile)
+                data: Dict[str, Dict[str, str]] = {
+                    'package.json': {},
+                    'package-lock.json': {},
+                }
+
+                for path, source in sources.items():
+                    original_version = f'{source.original}#{source.commit}'
+                    new_version = f'{path}#{source.commit}'
+                    data['package.json'][source.from_] = new_version
+                    data['package-lock.json'][original_version] = new_version
+
+                for filename, script in scripts.items():
+                    target = Path('$FLATPAK_BUILDER_BUILDDIR') / prefix / filename
+                    script =  textwrap.dedent(script.lstrip('\n')).strip().replace('\n', '')
+                    json_data = json.dumps(data[filename])
+                    init_commands[lockfile].append('jq'
+                                                   ' --arg buildroot "$FLATPAK_BUILDER_BUILDDIR"'
+                                                   f' --argjson data {shlex.quote(json_data)}'
+                                                   f' {shlex.quote(script)} {target}'
+                                                   f' > {target}.new')
+                    init_commands[lockfile].append(f'mv {target}{{.new,}}')
+
+        init_all_commands: List[str] = []
+        for lockfile in self.all_lockfiles:
+            init_dest = self.gen.data_root / 'init' / self.relative_lockfile_dir(lockfile)
+            # Don't use with_extension to avoid problems if the package has a . in its name.
+            init_dest = init_dest.with_name(init_dest.name + '.sh')
+
+            self.gen.add_script_source(init_commands[lockfile], init_dest)
+            init_all_commands.append(f'$FLATPAK_BUILDER_BUILDDIR/{init_dest}')
+
+        self.gen.add_script_source(init_all_commands, self.gen.data_root / 'init-all.sh')
+
+        if self.index_entries:
+            # (ab-)use a "script" module to generate the index.
+            parents: Set[str] = set()
+
+            for path in self.index_entries:
+                for parent in map(str, path.relative_to(self.cacache_dir).parents):
+                    if parent != '.':
+                        parents.add(parent)
+
+            index_commands: List[str] = []
+            index_commands.append('import os')
+            index_commands.append(f'os.chdir({str(self.cacache_dir)!r})')
+
+            for parent in sorted(parents, key=len):
+                index_commands.append(f'os.mkdir({parent!r})')
+
+            for path, entry in self.index_entries.items():
+                path = path.relative_to(self.cacache_dir)
+                index_commands.append(f'with open({str(path)!r}, "w") as fp:')
+                index_commands.append(f'    fp.write({entry!r})')
+
+            script_dest = self.gen.data_root / 'generate-index.py'
+            self.gen.add_script_source(index_commands, script_dest)
+            self.gen.add_command(f'python3 {script_dest}')
+
+
+class YarnLockfileProvider(LockfileProvider):
+    def unquote(self, string: str) -> str:
+        if string.startswith('"'):
+            assert string.endswith('"')
+            return string[1:-1]
+        else:
+            return string
+
+    def parse_package_section(self, lockfile: Path, section: List[str]) -> Package:
+        assert section
+        name_line = section[0]
+        assert name_line.endswith(':'), name_line
+        name_line = name_line[:-1]
+
+        name = self.unquote(name_line.split(',', 1)[0])
+        name, _ = name.rsplit('@', 1)
+
+        version: Optional[str] = None
+        resolved: Optional[str] = None
+        integrity: Optional[Integrity] = None
+
+        section_indent = 0
+
+        for line in section[1:]:
+            indent = 0
+            while line[indent].isspace():
+                indent += 1
+
+            assert indent, line
+            if not section_indent:
+                section_indent = indent
+            elif indent > section_indent:
+                # Inside some nested section.
+                continue
+
+            line = line.strip()
+            if line.startswith('version'):
+                version = self.unquote(line.split(' ', 1)[1])
+            elif line.startswith('resolved'):
+                resolved = self.unquote(line.split(' ', 1)[1])
+            elif line.startswith('integrity'):
+                integrity = Integrity.parse(line.split(' ', 1)[1])
+
+        assert version and resolved, line
+
+        source = ResolvedSource(resolved=resolved, integrity=integrity)
+        return Package(name=name, version=version, source=source, lockfile=lockfile)
+
+    def process_lockfile(self, lockfile: Path) -> Iterable[Package]:
+        section: List[str] = []
+
+        with open(lockfile) as fp:
+            for line in map(str.rstrip, fp):
+                if not line.strip() or line.strip().startswith('#'):
+                    continue
+
+                if not line[0].isspace():
+                    if section:
+                        yield self.parse_package_section(lockfile, section)
+                        section = []
+
+                section.append(line)
+
+        if section:
+            yield self.parse_package_section(lockfile, section)
+
+
+class YarnModuleProvider(ModuleProvider, ElectronModuleProviderMixin):
+    def __init__(self, gen: ManifestGenerator) -> None:
+        self.gen = gen
+        self.mirror_dir = self.gen.data_root / 'yarn-mirror'
+
+    def __exit__(self, *_: Any) -> None:
+        pass
+
+    async def generate_package(self, package: Package) -> None:
+        source = package.source
+        # Yarn doesn't use GitSource.
+        assert isinstance(source, ResolvedSource)
+
+        integrity = await source.retrieve_integrity()
+        url_parts = urllib.parse.urlparse(source.resolved)
+        destination = self.mirror_dir / os.path.basename(url_parts.path)
+
+        self.gen.add_url_source(source.resolved, integrity, destination)
+
+        if package.name == 'electron':
+            await self.generate_electron_modules(self.gen, package)
+
+
+class ProviderFactory:
+    def create_lockfile_provider(self) -> LockfileProvider:
+        raise NotImplementedError()
+
+    def create_module_provider(self, gen: ManifestGenerator) -> ModuleProvider:
+        raise NotImplementedError()
+
+
+class NpmProviderFactory(ProviderFactory):
+    def __init__(self, lockfile_root: Path, no_devel: bool, no_index: bool) -> None:
+        self.no_devel = no_devel
+        self.no_index = no_index
+        self.lockfile_root = lockfile_root
+
+    def create_lockfile_provider(self) -> NpmLockfileProvider:
+        return NpmLockfileProvider(self.no_devel)
+
+    def create_module_provider(self, gen: ManifestGenerator) -> NpmModuleProvider:
+        return NpmModuleProvider(gen, self.lockfile_root, self.no_index)
+
+
+class YarnProviderFactory(ProviderFactory):
+    def create_lockfile_provider(self) -> YarnLockfileProvider:
+        return YarnLockfileProvider()
+
+    def create_module_provider(self, gen: ManifestGenerator) -> YarnModuleProvider:
+        return YarnModuleProvider(gen)
+
+
+class GeneratorProgress(contextlib.AbstractContextManager):
+    def __init__(self, packages: Collection[Package], module_provider: ModuleProvider) -> None:
+        self.finished = 0
+        self.packages = packages
+        self.module_provider = module_provider
+        self.previous_package: Optional[Package] = None
+        self.current_package: Optional[Package] = None
+
+    def __exit__(self, *_: Any) -> None:
+        print()
+
+    def _format_package(self, package: Package, max_width: int) -> str:
+        result = f'{package.name} @ {package.version}'
+
+        if len(result) > max_width:
+            result = result[:max_width-3] + '...'
+
+        return result
+
+    def _update(self) -> None:
+        columns, _ = shutil.get_terminal_size()
+
+        sys.stdout.write('\r' + ' ' * columns)
+
+        prefix_string = f'\rGenerating packages [{self.finished}/{len(self.packages)}] '
+        sys.stdout.write(prefix_string)
+        max_package_width = columns - len(prefix_string)
+
+        if self.current_package is not None:
+            sys.stdout.write(self._format_package(self.current_package, max_package_width))
+
+        sys.stdout.flush()
+
+    def _update_with_package(self, package: Package) -> None:
+        self.previous_package, self.current_package = self.current_package, package
+        self._update()
+
+    async def _generate(self, package: Package) -> None:
+        self._update_with_package(package)
+        await self.module_provider.generate_package(package)
+        self.finished += 1
+        self._update_with_package(package)
+
+    async def run(self) -> None:
+        self._update()
+        await asyncio.wait(map(self._generate, self.packages))
+
+
+def scan_for_lockfiles(base: Path, patterns: List[str]) -> Iterator[Path]:
+    for root, dirs, files in os.walk(base.parent):
+        if base.name in files:
+            lockfile = Path(root) / base.name
+            if not patterns or any(map(lockfile.match, patterns)):
+                yield lockfile
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Flatpak Node generator')
+    parser.add_argument('type', choices=['npm', 'yarn'])
+    parser.add_argument('lockfile', help='The lockfile path (package-lock.json or yarn.lock)')
+    parser.add_argument('-o', '--output', help='The output sources file',
+                        default='generated-sources.json')
+    parser.add_argument('-r', '--recursive', action='store_true',
+                        help='Recursively process all files under the lockfile directory with '
+                             'the lockfile basename')
+    parser.add_argument('-R', '--recursive-pattern', action='append',
+                        help='Given -r, restrict files to those matching the given pattern.')
+    parser.add_argument('--no-devel', action='store_true',
+                        help="Don't include devel dependencies (npm only)")
+    parser.add_argument('--no-index', action='store_true',
+                        help='Skip building the cacache index (npm only)')
+    parser.add_argument('--no-aiohttp', action='store_true',
+                        help="Dont' use aiohttp, and silence any warnings related to it")
+    # Internal option, useful for testing.
+    parser.add_argument('--stub-requests', action='store_true', help=argparse.SUPPRESS)
+
+    args = parser.parse_args()
+
+    if args.type == 'yarn' and (args.no_devel or args.no_devel):
+        sys.exit('--no-devel and --no-index do not apply to Yarn.')
+
+    if args.stub_requests:
+        Requests.instance = StubRequests()
+    elif args.no_aiohttp:
+        if Requests.instance.is_async:
+            Requests.instance = UrllibRequests()
+    elif not Requests.instance.is_async:
+        print('WARNING: aiohttp is not found, performance will suffer.', file=sys.stderr)
+        print('  (Pass --no-aiohttp to silence this warning.)', file=sys.stderr)
+
+    lockfiles: List[Path]
+    if args.recursive or args.recursive_pattern:
+        lockfiles = list(scan_for_lockfiles(Path(args.lockfile), args.recursive_pattern))
+        if not lockfiles:
+            sys.exit('No lockfiles found.')
+        print(f'Found {len(lockfiles)} lockfiles.')
+    else:
+        lockfiles = [Path(args.lockfile)]
+
+    lockfile_root = Path(args.lockfile).parent
+
+    provider_factory: ProviderFactory
+    if args.type == 'npm':
+        provider_factory = NpmProviderFactory(lockfile_root, args.no_devel, args.no_index)
+    elif args.type == 'yarn':
+        provider_factory = YarnProviderFactory()
+    else:
+        assert False, args.type
+
+    print('Reading packages from lockfiles...')
+    packages: Set[Package] = set()
+
+    for lockfile in lockfiles:
+        lockfile_provider = provider_factory.create_lockfile_provider()
+        packages.update(lockfile_provider.process_lockfile(lockfile))
+
+    print(f'{len(packages)} packages read.')
+
+    gen = ManifestGenerator()
+    with gen:
+        with provider_factory.create_module_provider(gen) as module_provider:
+            with GeneratorProgress(packages, module_provider) as progress:
+                await progress.run()
+
+    with open(args.output, 'w') as fp:
+        json.dump(gen.sources, fp, indent=4)
+
+    print(f'Wrote {len(gen.sources)} sources.')
+
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())

--- a/node/mypy.ini
+++ b/node/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_return_any = true

--- a/node/vanilla-quick-start/README.md
+++ b/node/vanilla-quick-start/README.md
@@ -1,0 +1,10 @@
+# vanilla-quick-start
+
+Showcases building a Flatpak of the Electron 4 version of
+[electron-quick-start](https://github.com/electron/electron-quick-start).
+
+To create generated-sources.json run:
+
+```
+flatapk-node-generator.py npm /path/to/electron-quick-start/package-lock.json
+```

--- a/node/vanilla-quick-start/org.electronjs.ElectronQuickStart.yaml
+++ b/node/vanilla-quick-start/org.electronjs.ElectronQuickStart.yaml
@@ -39,10 +39,12 @@ modules:
     build-options:
       # Add the node bin directory.
       append-path: /usr/lib/sdk/node10/bin
-      # Set the Electron cache directory.
-      # (The directory format is: /run/build/MODULE_NAME/flatpak-node/electron-cache)
       env:
+        # Set the Electron cache directory.
+        # (The directory format is: /run/build/MODULE_NAME/flatpak-node/electron-cache)
         ELECTRON_CACHE: '/run/build/electron-quick-start/flatpak-node/electron-cache'
+        # Sets the directory where Node is located so way npm won't download the headers.
+        npm_config_nodedir: '/usr/lib/sdk/node10'
     build-commands:
       # Install the packages from our offline cache.
       # --prefix= is the path to our subdirectory (see the electron-quick-start source below).

--- a/node/vanilla-quick-start/org.electronjs.ElectronQuickStart.yaml
+++ b/node/vanilla-quick-start/org.electronjs.ElectronQuickStart.yaml
@@ -1,0 +1,73 @@
+app-id: org.electronjs.ElectronQuickStart
+branch: stable
+runtime: org.freedesktop.Platform
+runtime-version: '18.08'
+sdk: org.freedesktop.Sdk
+# Use the Electron 2 BaseApp, which adds several common libraries we'll need.
+base: org.electronjs.Electron2.BaseApp
+base-version: stable
+# Add the Node 10 SDK extension.
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node10
+# Electron doesn't use a traditional locale format so separate-locales is useless.
+separate-locales: false
+command: start-electron-quick-start
+finish-args:
+  # These two lines add Xorg access for graphics.
+  - '--share=ipc'
+  - '--socket=x11'
+  # Sound access.
+  - '--socket=pulseaudio'
+  # Network access.
+  - '--share=network'
+  # If you need to access the filesystem, also add:
+  # - '--filesystem=home'
+modules:
+  # First step is to install Node to /app/node, that way it can be accessible outside of the sdk
+  # environment.
+  # (This does not need to be done for electron-builder, see
+  # electron-webpack-quick-start's build.electron.webpack.ElectronWebpackQuickStart.yaml for an
+  # explanation.)
+  - name: node
+    buildsystem: simple
+    build-commands:
+      - '/usr/lib/sdk/node10/install.sh'
+
+  # Now is the quickstart module.
+  - name: electron-quick-start
+    buildsystem: simple
+    build-options:
+      # Add the node bin directory.
+      append-path: /usr/lib/sdk/node10/bin
+      # Set the Electron cache directory.
+      # (The directory format is: /run/build/MODULE_NAME/flatpak-node/electron-cache)
+      env:
+        ELECTRON_CACHE: '/run/build/electron-quick-start/flatpak-node/electron-cache'
+    build-commands:
+      # Install the packages from our offline cache.
+      # --prefix= is the path to our subdirectory (see the electron-quick-start source below).
+      # If you were using Yarn here, you'd use the yarn config and yarn --offline commands
+      # as shown in the webpack-quick-start demo. The need for --prefix= is dependent on how
+      # this project is run, not on the package manager.
+      - 'npm install --prefix=electron-quick-start --offline --cache=$FLATPAK_BUILDER_BUILDDIR/flatpak-node/npm-cache'
+
+      # This quick start is designed for running directly from the source directory, so we
+      # copy it resulting directory to /app/electron-quick-start. (This isn't npm-specific.)
+      - 'cp -r electron-quick-start /app'
+      # Install the wrapper script to start it.
+      - 'install -Dm 755 start-electron-quick-start.sh /app/bin/start-electron-quick-start'
+    sources:
+      - type: git
+        url: https://github.com/electron/electron-quick-start
+        # Use the Electron 4 / Node 10 version.
+        commit: 474280be1d822f21606f02789bc098884913b942
+        # Checkout into a subdirectory so we can copy the whole thing to /app.
+        dest: electron-quick-start
+      # Add the flatpak-node-generator generated sources.
+      - generated-sources.json
+      # Our runner script.
+      - type: script
+        dest-filename: start-electron-quick-start.sh
+        commands:
+          - 'export PATH=$PATH:/app/node/bin'
+          - 'npm start --prefix=/app/electron-quick-start'

--- a/node/webpack-quick-start/README.md
+++ b/node/webpack-quick-start/README.md
@@ -1,0 +1,10 @@
+# webpack-quick-start
+
+Showcases building a Flatpak of [electron-webpack-quick-start](
+https://github.com/electron-userland/electron-webpack-quick-start/).
+
+To create generated-sources.json run:
+
+```
+flatapk-node-generator.py yarn /path/to/electron-webpack-quick-start/yarn.lock
+```

--- a/node/webpack-quick-start/build.electron.webpack.ElectronWebpackQuickStart.yaml
+++ b/node/webpack-quick-start/build.electron.webpack.ElectronWebpackQuickStart.yaml
@@ -1,0 +1,77 @@
+app-id: build.electron.webpack.ElectronWebpackQuickStart
+branch: stable
+runtime: org.freedesktop.Platform
+runtime-version: '18.08'
+sdk: org.freedesktop.Sdk
+# Use the Electron 2 BaseApp, which adds several common libraries we'll need.
+base: org.electronjs.Electron2.BaseApp
+base-version: stable
+# Add the Node 10 SDK extension.
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node10
+# Electron doesn't use a traditional locale format so separate-locales is useless.
+separate-locales: false
+command: start-electron-webpack-quick-start
+finish-args:
+  # These two lines add Xorg access for graphics.
+  - '--share=ipc'
+  - '--socket=x11'
+  # Sound access.
+  - '--socket=pulseaudio'
+  # Network access.
+  - '--share=network'
+  # If you need to access the filesystem, also add:
+  # - '--filesystem=home'
+modules:
+  # With electron-webpack and electron-builder we don't install Node to /app/node,
+  # because electron-builder will bundle everything for us in one piece.
+  # Instead we jump straight to the quick start module.
+
+  # However, since this quick start uses yarn, we do have to install that.
+  - name: yarn
+    buildsystem: simple
+    build-commands:
+      - 'cp -a * /app'
+    # Only used for building, so clean it up afterwards.
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        url: https://github.com/yarnpkg/yarn/releases/download/v1.16.0/yarn-v1.16.0.tar.gz
+        sha256: df202627d9a70cf09ef2fb11cb298cb619db1b958590959d6f6e571b50656029
+
+  - name: electron-webpack-quick-start
+    buildsystem: simple
+    build-options:
+      # Add the node bin directory & yarn directory.
+      append-path: '/usr/lib/sdk/node10/bin:/app/yarn/bin'
+      # Set the Electron cache directory.
+      # (The directory format is: /run/build/MODULE_NAME/flatpak-node/electron-cache)
+      env:
+        ELECTRON_CACHE: '/run/build/electron-webpack-quick-start/flatpak-node/electron-cache'
+    build-commands:
+      # Have Yarn use the offline mirror.
+      - 'HOME=$PWD yarn config --offline set yarn-offline-mirror $FLATPAK_BUILDER_BUILDDIR/flatpak-node/yarn-mirror'
+      # Download the packages.
+      - 'yarn --offline'
+      # If you were using npm with electron-webpack/electron-builder, then the above two commands
+      # would look more like the npm commands in the vanilla-quick-start manifest, just without
+      # the --prefix.
+
+      # Run electron-builder.
+      - 'yarn run --offline dist:dir'
+      # Copy the resulting, unpacked directory to /app.
+      - 'cp -r dist/linux-unpacked /app/electron-webpack-quick-start'
+      # Install the wrapper script to start it.
+      - 'install -Dm 755 start-electron-webpack-quick-start.sh /app/bin/start-electron-webpack-quick-start'
+    sources:
+      - type: git
+        url: https://github.com/electron-userland/electron-webpack-quick-start
+        commit: 1f89987d8ce748f0e43548f452cd8a699b28a1d4
+      # Add the flatpak-node-generator generated sources.
+      - generated-sources.json
+      # Our runner script.
+      - type: script
+        dest-filename: start-electron-webpack-quick-start.sh
+        commands:
+          - '/app/electron-webpack-quick-start/electron-webpack-quick-start'

--- a/node/webpack-quick-start/build.electron.webpack.ElectronWebpackQuickStart.yaml
+++ b/node/webpack-quick-start/build.electron.webpack.ElectronWebpackQuickStart.yaml
@@ -45,10 +45,12 @@ modules:
     build-options:
       # Add the node bin directory & yarn directory.
       append-path: '/usr/lib/sdk/node10/bin:/app/yarn/bin'
-      # Set the Electron cache directory.
-      # (The directory format is: /run/build/MODULE_NAME/flatpak-node/electron-cache)
       env:
+        # Set the Electron cache directory.
+        # (The directory format is: /run/build/MODULE_NAME/flatpak-node/electron-cache)
         ELECTRON_CACHE: '/run/build/electron-webpack-quick-start/flatpak-node/electron-cache'
+        # Sets the directory where Node is located so way npm won't download the headers.
+        npm_config_nodedir: '/usr/lib/sdk/node10'
     build-commands:
       # Have Yarn use the offline mirror.
       - 'HOME=$PWD yarn config --offline set yarn-offline-mirror $FLATPAK_BUILDER_BUILDDIR/flatpak-node/yarn-mirror'

--- a/node/webpack-quick-start/generated-sources.json
+++ b/node/webpack-quick-start/generated-sources.json
@@ -1,0 +1,6930 @@
+[
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d",
+        "sha1": "097b602b53422a522c1afb8790318336941a011d",
+        "dest-filename": "number-is-nan-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4",
+        "sha512": "6ab9d73314f5861a0aa3d9352d976694dc897430dfcb6bf47d78c5966a24e3e8bcba5ffa5a56d581ef5b84cef83a934f40f306513a03b73f8a5dad4f9de27138",
+        "dest-filename": "is-extendable-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.3.tgz#32f5df65744b70888d17872ec106b02434ba1489",
+        "sha512": "d0bc8471595f0a8166722f265f1f00e68224a643a0ca8f1d447b710672bd451070c4edbe2593cdb2ab5511943b98914fc675c5f657e6536e261ce3c8d2a9e590",
+        "dest-filename": "@babel-parser-7.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/single-line-log/-/single-line-log-1.1.2.tgz#c2f83f273a3e1a16edb0995661da0ed5ef033364",
+        "sha1": "c2f83f273a3e1a16edb0995661da0ed5ef033364",
+        "dest-filename": "single-line-log-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8",
+        "sha512": "9e77bdfc8890fe1cc8858ea97439db06dcfb0e33d32ab634d0fff3bcf4a6e69385925eb1b86ac69d79ff56d4cd35f36d01f67dff546d7a192ccd4f6a7138a2d1",
+        "dest-filename": "abbrev-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/compressible/-/compressible-2.0.15.tgz#857a9ab0a7e5a07d8d837ed43fe2defff64fe212",
+        "sha512": "e1a13aec32f7ddd496f60c38088d87ff24f1a872cd731a74c92ea307ee21fb0af77b8dfed73eef9b41d4f6a5ce1fc8feaa32ae2fcf94b643b161048cabad1897",
+        "dest-filename": "compressible-2.0.15.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.4.tgz#3a56e3cbf589ca0081eb22cd9ba0b1290a16d26e",
+        "sha512": "3f17c6cd2b34ced4a12ab5183c89f9af432dc80858702c269dda33ce9cfc60e6db3e70f58c5c7394119b4675f6988bba675df137af8f4eed394d0167645973a3",
+        "dest-filename": "js-levenshtein-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/posthtml/-/posthtml-0.11.3.tgz#17ea2921b0555b7455f33c977bd16d8b8cb74f27",
+        "sha512": "aae3079c3724b760d0f65462e9b60b9eec810e75732be31c1daf3e6abe244dd61b584a3ff7685110ebb787bd198abb9d38ea7f9b2d9bdebd26e58b71639db2ac",
+        "dest-filename": "posthtml-0.11.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8",
+        "sha512": "4770b875be9b8108652213d4e3c7d4b5d5662a77e5abe85175a77b2322a1b458f4e953cd55d9364618982f752340896ca3c2fe63102d164a1b4f454af92ff26e",
+        "dest-filename": "mime-db-1.37.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
+        "sha512": "156b6578d02d67f2a2daab6a7a3d825d339ac8e1fd6c70d017e438f15a56c835e36d8c40e18cfc883077d735ce05494e1c72a27436ea195ad352f40c3e604607",
+        "dest-filename": "to-regex-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-6.5.3.tgz#95afe3deab33fd874f68d299bc71b481e94f5312",
+        "sha512": "64d978185060eab745a659eea0ae7a89fb7187faa033bad7254c60976d5e2b85ac8f1810c2d434444668fa90d22f83b355ec8e3bc30c35648d41c0ac04b883c8",
+        "dest-filename": "dmg-builder-6.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf",
+        "sha512": "c0f314b7a1671f6cb31bde5203a9b38d038429453768b683126cecd6d8bed44f61f82b2b66085196a10cfc42782ac72c4151bcb8d378b95ade51e4fcf9dae582",
+        "dest-filename": "commander-2.17.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194",
+        "sha512": "1d1915bffe6a6361ba23c89a6fd708eefd5b3887619bde1d5634023c51255bd5bedc67833921e6cb610161ee154c0a6ece894f7268054cdddfb55251291d89f5",
+        "dest-filename": "type-is-1.6.16.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768",
+        "sha512": "81ddf2a483df38cafd8798c82aaf04dec1ce4c28de8ab9e5d162b965d4b5016d0e76dd1bd4f696687749e10938925bfe601f5a2414bb9844978c5a0340fbba0c",
+        "dest-filename": "dom-converter-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3",
+        "sha512": "fc4e7b018928790db9aa4c4c8f93c1395805f0a8aefe1edc612df4679f91ed66a208205f2eae7c648fdd49e68429bf565495799ffd37430acddc8796205965bf",
+        "dest-filename": "pkg-dir-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c",
+        "sha512": "61f253eeb929401d2ea5db1d1cb196aef84125f71fccd35ac180cd232417273d0856219fef93bc1013ca49dbf0dab17e2c60ac5f8159f2d72bddbd7d2dc66ae3",
+        "dest-filename": "is-ci-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
+        "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
+        "dest-filename": "isobject-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "sha1": "9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "dest-filename": "imurmurhash-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.2.1.tgz#578558ef23befac043a1abb0db07635509393479",
+        "sha512": "4905422c54b613b1b909108c767e8af5b221463d5b4ba4015997c5d1350f87857f05baab43ad7d21d492dff8b39f4159fbd97eb8e0f36998dbd3c7e339f69b94",
+        "dest-filename": "domelementtype-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca",
+        "sha1": "625d8658f865af43ec962bfc376a37359a4994ca",
+        "dest-filename": "select-hose-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec",
+        "sha512": "7f3e2ca4887ece78ced958cbf88761129449dd837ab0ccc84d20628e4e852b652f4eaaee4905befdc0994d236c32264dbd47aad02aaeac5f9d01bca218e63a5a",
+        "dest-filename": "crypto-browserify-3.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348",
+        "sha1": "f86e6374d43205a6e6c60e9196f17c0299bfb348",
+        "dest-filename": "loader-utils-0.2.17.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-loader/-/css-loader-2.1.0.tgz#42952ac22bca5d076978638e9813abce49b8f0cc",
+        "sha512": "3283aef824adb06ad2b792b639e67cf6add29dff8893145f008b7d6802a0e298a2a13ae1b4fd621053eef8e567dce873db814ee8bfabc3d509c4120b892070e5",
+        "dest-filename": "css-loader-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b",
+        "sha1": "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b",
+        "dest-filename": "esutils-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "dest-filename": "which-module-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd",
+        "sha512": "6f3a47fe8061a12fd023f62d6e4a8283a54488f623499b6b1d033afd09c94ba38bf6929414ba9bdda161e1272fc26e39fbb8808223242e149b699c54aa6ae9af",
+        "dest-filename": "upath-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+        "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+        "dest-filename": "object.pick-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace",
+        "sha512": "644cf2e2f8ef4f349c0be487f1106cb1051ac296889d474c4d8c1860b879e3fb3c4ee4f48012eec949e9a4ab15c99122f3be959a64ad2ac52cdbc5313e076fac",
+        "dest-filename": "@webassemblyjs-ast-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9",
+        "sha1": "cf61090da0d9efbcab8722deba6f032208dbb0e9",
+        "dest-filename": "is-svg-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644",
+        "sha512": "498d4c9a996cb0e45f1622c370e113ad6edf08b97e3dabe5c0c87ddabac6722910691ab88963d51f4329c0fa58ddeb55331e919c38d7b6be95658aff21b3ff02",
+        "dest-filename": "@babel-template-7.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz#d2b4bd9d5ced5ebd8dcade7640c7d7cd7f4f92b5",
+        "sha1": "d2b4bd9d5ced5ebd8dcade7640c7d7cd7f4f92b5",
+        "dest-filename": "postcss-discard-empty-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05",
+        "sha1": "96918440e3041a7a414f8c52e3c574eb3c3e1e05",
+        "dest-filename": "extsprintf-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf",
+        "sha1": "dcd8488a26f563d61079e48c9f7b7e32373682cf",
+        "dest-filename": "domutils-1.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
+        "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "dest-filename": "color-name-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc",
+        "sha512": "775c45b3e0bf20f4bc21dd2a3d36786d44fcc16af27d1fcecf3005c70786fae2cdf39a0fcf2a36230e9b5652d0fc939d80da275cb0a8472a83cc35aae22c3bd8",
+        "dest-filename": "node-pre-gyp-0.10.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+        "sha1": "450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+        "dest-filename": "util-deprecate-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80",
+        "sha1": "978857442c44749e4206613e37946205826abd80",
+        "dest-filename": "destroy-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea",
+        "sha1": "44aac65b695b03398968c39f363fee5deafdf1ea",
+        "dest-filename": "shebang-command-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9",
+        "sha512": "9abab264a7d7e4484bee1bea715e961b5c988e78deb980f30e185c00052babc3e8f3934140124ff990d44fbe6a650f7c22452806a76413192e90e53b4ecdb0af",
+        "dest-filename": "json-parse-better-errors-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea",
+        "sha512": "b0ace91247f5d46a4e16ec346738f39ade01e146708ce706ef9ecf3efadf87170b15bab4c29b20a4eab1a71b71162086e03b46f7733a5d155b176a0675ebfb6e",
+        "dest-filename": "global-modules-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.35.tgz#cf933a9a9a38484ca724b335b88d83726d5ab960",
+        "sha512": "cbd5d3d750a8cc70e08d67137719a14a3d77ac9557a5ae595f08e33a24de76368cd1b6b922da9d4b4daddf51213e5ec7b4e5b1b1991808250dad27eb3a2b00eb",
+        "dest-filename": "@babel-types-7.0.0-beta.35.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz#5fc31de522ec0ef0899dc9b3e7cf6a5dd655f362",
+        "sha512": "06f703598651595b837974d8656c5e91034ee43e243b9e5a02bc19393157c3aae52d003c65a0e2709475b0ee3b87e1eb9c2883162c30d1f48f57477bd7728119",
+        "dest-filename": "@babel-helper-replace-supers-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f",
+        "sha512": "811e91c3832f525632f37bcfd2fc6854dccceadf0c517a8db91b2e066047403bb5161e97d35e45acb760a0329c35d9301ae6e8cead0fe0dd10dfb532155af510",
+        "dest-filename": "source-map-support-0.5.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz#df38882a624080d03f7503f93e3f17ac5ac01181",
+        "sha512": "9ec01058d3f5fbc67ab64cdd6255d3d24c5f6b6675b514c045df3062773f7b766fdd5c9d5559da79e3e0a94cc5ae99065328545313a5e4c2fb7f536e4fe802d0",
+        "dest-filename": "@webassemblyjs-helper-fsm-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a",
+        "sha512": "06c5cbcf9b2a5fc38772c87b0aa04ccedc970119864372d63ed1a3262e838891eae42feabe2f4fdceaa0b302920dfb5bbbcf88a08fd00d3026d9f16743d49949",
+        "dest-filename": "elliptic-6.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e",
+        "sha512": "ec03bbe3cc169c884da80b9ab72d995879101d148d7cf548b0f21fc043963b6d8099aa15ad66af94e70c4799f34cb358be9dfa5f6db4fe669a46cade7351bae4",
+        "dest-filename": "locate-path-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
+        "sha512": "7f676f3b4554e8e7a3ed1916246ade8636f33008c5a79fd528fa79b53a56215e091c764ad7f0716c546d7ffb220364964ded3d71a0e656d618cd61086c14b8cf",
+        "dest-filename": "has-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz#68b8a438663e88519e65b776f8938f3445b1a2ff",
+        "sha512": "0841f383883952b6917a8cc8f43e1f6e5058001b3b20ce947ab0151bb10956b4cb0b991e874d1a12e2d44fe3b8d3e989084cda5e461f4c250a2327837cc38515",
+        "dest-filename": "@babel-plugin-transform-async-to-generator-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz#8b1eaf554f686fb288cd874c55667b0aa3668d58",
+        "sha1": "8b1eaf554f686fb288cd874c55667b0aa3668d58",
+        "dest-filename": "postcss-discard-overridden-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+        "sha1": "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+        "dest-filename": "path-exists-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9",
+        "sha1": "54dbf377e51440aca90a4cd274600d3ff2d888a9",
+        "dest-filename": "relateurl-0.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-color/-/parse-color-1.0.0.tgz#7b748b95a83f03f16a94f535e52d7f3d94658619",
+        "sha1": "7b748b95a83f03f16a94f535e52d7f3d94658619",
+        "dest-filename": "parse-color-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdy/-/spdy-4.0.0.tgz#81f222b5a743a329aa12cea6a390e60e9b613c52",
+        "sha512": "a2dd281064ff3c6529cdfffaba4e0058baa4abe8ab96a1d792b75b939d6858e361ddbc50981ba58f13cd97aeb395145c2094ad5aad1090b5023ce3e3823bd4d1",
+        "dest-filename": "spdy-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85",
+        "sha512": "3a25604ab6c6bbb3449c4bd024981d4853e5daa58a916ab99473218224e822237dc37e040678d8cd262cf956cbe4aa1888b36d1456bb05920ac51103dc8df6a4",
+        "dest-filename": "webpack-sources-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525",
+        "sha512": "d4953ff2af95805672c70ac9f925483ac87e2b2c161a976cdcd4ea8a488aa43319592726018c8a220aa43be011bcd5897d7797475cf1cfb687178bb80b21fabd",
+        "dest-filename": "readdirp-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087",
+        "sha512": "ce1482b6df2fd8d0eb4653d0a4236dc3f85e64bb5f503ab104cd6e76a8a46ff1db939d8b2b89d04b0af5d2eefb8a8a425b92ecc87a6e5d2d069c4738f262de7b",
+        "dest-filename": "statuses-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8",
+        "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
+        "dest-filename": "extend-shallow-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6",
+        "sha1": "65ac0504b3954171d8a64946b2ae3cbb8a5f54f6",
+        "dest-filename": "supports-color-3.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2",
+        "sha1": "9a5f699051b1e7073328f2a008968b64ea2955d2",
+        "dest-filename": "array-flatten-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30",
+        "sha1": "9cafb171af82329490353b4816f03347aa150a30",
+        "dest-filename": "7zip-0.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d",
+        "sha512": "99840b667c7942dd49801d561223027f6eb8ee996919e43634c47fe4bd07359cc6428e1fb923e72bec237cf9ca655d1a8890e0ce65aaaa457f83b243f835b4ab",
+        "dest-filename": "capture-stack-trace-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e",
+        "sha1": "71a50c8429dfca773c92a390a4a03b39fcd51d3e",
+        "dest-filename": "is-plain-obj-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd",
+        "sha1": "27a5dea06b36b04a0a9966774b290868f0fc40fd",
+        "dest-filename": "tunnel-agent-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72",
+        "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
+        "dest-filename": "is-utf8-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20",
+        "sha512": "24bdfd73ad1797309580dacefaaabaf05a0d6f9eb0fe6ec962f191da34f9891d7106b500dcc7f1e53c24e6ba934e13e640a316c9d1a6abca05b439717eb9b19d",
+        "dest-filename": "registry-auth-token-3.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502",
+        "sha1": "e6c80b623123d7d80cf132ce538f346289072502",
+        "dest-filename": "stat-mode-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff",
+        "sha1": "b31c5ae8254844a3a8281541ce2b04b865a734ff",
+        "dest-filename": "uniq-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.3.tgz#264bd9ff38a8ce24b06e0636496b2c856b57bcbb",
+        "sha512": "e62a53ad9152ab9bd4d98a06a30c38b9a45500ae30c980b84d220289b6df10f3abb94bbc1453fb12b57406399b20e1299f73bf93d9daf5411d611ff79bb37ab8",
+        "dest-filename": "regenerator-transform-0.13.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a",
+        "sha1": "9e1057cca851abb93398f8b33ae187b99caec11a",
+        "dest-filename": "unique-string-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892",
+        "sha512": "2f3aad2ca954c22ac453297f9e2722ad598d88fbd8b3b9799fcc0e3cfedfc8956950f92f0a75bfbee8971a9ca51949673c39c1ef7d75ac047302ddcc86cc298e",
+        "dest-filename": "killable-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4",
+        "sha1": "496b2cc109eca8dbacfe2dc72b603c17c5870ad4",
+        "dest-filename": "xdg-basedir-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac",
+        "sha1": "de819fdbcd84dccd8fae59c6aeb79615b9d266ac",
+        "dest-filename": "math-expression-evaluator-1.2.17.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc",
+        "sha1": "1b681c21ff84033c826543090689420d187151dc",
+        "dest-filename": "caseless-0.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1",
+        "sha1": "3c0434743df93e2f5c42aee7b19bcb483575f4e1",
+        "dest-filename": "json3-3.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803",
+        "sha512": "2622b4e21d07b79bbff347dd2cc084995e3390d87605ca0c141999ffdd56b5867ca955d22a38b0edf5cc8053e71dc49980ea375dd8a71ef9a70d478c7f9478c0",
+        "dest-filename": "domhandler-2.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73",
+        "sha1": "ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73",
+        "dest-filename": "https-browserify-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae",
+        "sha1": "3fbcfb15b899a44123b34b6dcc18b724336a2cae",
+        "dest-filename": "p-finally-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a",
+        "sha1": "612da1c96473fa02dccda92dcd5b4ab164a6772a",
+        "dest-filename": "sanitize-filename-1.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-6.7.0.tgz#e3ce7bb372d6577bb1839f1dfdfcbf5ad2948d96",
+        "sha512": "4595cfbe2053b5f9ad91af67f6ccb53793396fcd826f158847a1c88ace2cdd64135c325a99cff4829096346cfa116756a780ce7e3cc97e1cff012f7354f8e35a",
+        "dest-filename": "ajv-6.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9",
+        "sha1": "7afb1afe50805246489e3db7fe0ed379336ac0f9",
+        "dest-filename": "util-0.10.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02",
+        "sha1": "ffede4b36b25290696e6e165d4a59edb998e6b02",
+        "dest-filename": "uniqs-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e",
+        "sha512": "9cea87e7d75e0aaf52447971ab5030f39267b78c3a2af2caa9656293aa00f599255cb3483a5aa0e05db2ad3d4c55a4e302abd5c1d7de67bc3b682bc90fbba093",
+        "dest-filename": "string-width-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16",
+        "sha1": "dc34314f4e679318093fc760272525f94bf25c16",
+        "dest-filename": "batch-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af",
+        "sha1": "a5c6d532be656e23db820efb943a1f04998d63af",
+        "dest-filename": "xtend-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907",
+        "sha512": "cd12f420c334d80503c2085fe4b312483133eec0423b6627366a60dee593663fefd6b706d8199052f68653c1a153c06f7cc87593628801867b262f4a5cf520ee",
+        "dest-filename": "@babel-template-7.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a",
+        "sha1": "b06873934bc5e344fef611a196a6faae0aee015a",
+        "dest-filename": "connect-history-api-fallback-1.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3",
+        "sha1": "fc289d4ed8993119460c156253262cdc8de65bf3",
+        "dest-filename": "parseurl-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196",
+        "sha512": "cf4d1b0863470c6f261c090fec2b53d6a56ef9b15050f8d8abfe08bf70b79168d3155d74cc88df4a87aa5e8f40b30b3c8304870c68ff865daee0e1888daa5e0a",
+        "dest-filename": "create-hash-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89",
+        "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
+        "dest-filename": "isobject-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-download/-/electron-download-4.1.1.tgz#02e69556705cc456e520f9e035556ed5a015ebe8",
+        "sha512": "1631161bd25bfe9a4aff6cd3a0ff94e5d76cd75e1f33564e26a3004786975cbe42bf23c4f5f8aa04affd61cc02f69a081504c4264fc433fcf2470ce2ce2459ae",
+        "dest-filename": "electron-download-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz#3b74caec329b3c80c116290887c0dd9ae468c20c",
+        "sha512": "c8f3dc5bc75cde064b37e5359a1615f75414de7e6e4dbc7b0d475ff0d9cf6e34b444cc01b878bd5edd8c520a6998dcfb089c53056b067334e2129d4248e4cf46",
+        "dest-filename": "@babel-helper-define-map-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a",
+        "sha1": "7ba5ae24217804ac70707b96922567486cc3e84a",
+        "dest-filename": "is-glob-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598",
+        "sha512": "54cca13d8648485640a803d592261bedd51ed80b158b6ff0093e7ec1976c34edf51688d025af67b38d21cd9e94f5fe74265ab8c3aab0cdd041daec2a674d1e6e",
+        "dest-filename": "@babel-plugin-transform-object-super-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.7.11.tgz#06d7218ea9fdc94a6793aa92208160db3d26ee82",
+        "sha512": "0ba18591ceda12b408007f8132b21d552996fba1d27b6d30839ec7102d6ea893fc13fc693235ea414c64430d3b321343483706a7123d1b925234e402a89938b0",
+        "dest-filename": "@webassemblyjs-utf8-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz#5b41686b4ed40bef874d7ed6a84bdd849c13e0c1",
+        "sha512": "b23daacec131f0a0d5bf542e25cfdd11f8a5920dd144fbcf631fd59ca2ed22d550456b755aa7f979508e2d99b6f4288615f618b00dd53e37e2cd3095d12d0397",
+        "dest-filename": "@babel-plugin-transform-regenerator-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61",
+        "sha1": "f45f150c4c66eee968186505ab93fcbb8ad6bf61",
+        "dest-filename": "utf8-byte-length-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.35.tgz#308e350e731752cdb4d0f058df1d704925c64e0a",
+        "sha512": "bda0b52b22194aec966f72e3dbbedf5f4a718afc87c2e0d4e3166ca1faa06006e40f136278c836bee8733f902033078c63b7c24143138be0603ea4cb8e4c5716",
+        "dest-filename": "@babel-helper-module-imports-7.0.0-beta.35.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24",
+        "sha1": "1d03dded53bd8db0f30c26e4f95d36fc7c87dc24",
+        "dest-filename": "is-redirect-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.3.3.tgz#3fe986fca9f00c0f109d731ba590b192f26e776d",
+        "sha512": "1ff67fc971b0978f40ee16102d5d6243787cecd134699fcf319845c21c3794a78200df938b889dac7bd5be1e3f197d7423bbbbeda430f90078bd5e7f2f3befe4",
+        "dest-filename": "posthtml-parser-0.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9",
+        "sha1": "2b327184e8992101177b28563fb5e7102acd0ca9",
+        "dest-filename": "negotiator-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz#abe7281fe46c95ddc143a65e5358647792039520",
+        "sha512": "2ef45561bee48a4b8eb48a147964e43b1404575918bcbe41e94de2584182ccf351bacd4ccc9c1e16a3914e3fb48e4c68ce44d260d268ccf39d7719aa76ab11a7",
+        "dest-filename": "@babel-plugin-proposal-unicode-property-regex-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7",
+        "sha512": "40c129e41edc7ed13b00f3a393963ac60adb5aef9690b550c24f0936367c9ca45c899681c845ba32e6e2780893a12efe770beb8c6847f23457cf7315774018a9",
+        "dest-filename": "sha.js-2.4.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+        "sha1": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+        "dest-filename": "string-width-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz#f7930362829ff99a3174c39f0afcc024ef59731a",
+        "sha512": "916824b28c3d94776f042d99e26c53b2f73b61d63bc3f57a076bf2f5c4c83ed2c413d361c285a2bdac5d34cfd2dfb7a5bb96ea94b3ffa8e63dd3a2ee90ef6591",
+        "dest-filename": "@babel-plugin-transform-function-name-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e",
+        "sha1": "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e",
+        "dest-filename": "boolbase-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d",
+        "sha512": "346104ae71fa176bd4b970e1f8e95b70a5bbff039c7dd447699ed55ada82ced7c7ae2ffef982a63f9d4e7567863eea8239b6ba924d8e4dee5dd365664c1f343f",
+        "dest-filename": "kind-of-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7",
+        "sha512": "8d055e7911bbd10234f2f493c1fd631f1a7be09a19b2bd974a011369ef3fc42f28bd29cbd9617cec64cb3bce926f076dda52b85268381e79f030ee1817709eef",
+        "dest-filename": "css-select-base-adapter-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7",
+        "sha512": "3fe33ae50636250e58d06f4a29d943a68d332befce1e9b54e40681c147c02032599353187f7d85ae6f3811c3b2b5f244d2de49be40272a59a3b170e75b308999",
+        "dest-filename": "html-comment-regex-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56",
+        "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
+        "dest-filename": "is-data-descriptor-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz#261a50337e37121d338b966f07922eb4939a8763",
+        "sha512": "6f991c33786652a9fae3e4547078e3afc64ca474b6589e583b4a671bdf8ffd14ddc78ea87ff26b123b9c8875aec7aa44f8e9faca75a11c9179de3fc40c93743c",
+        "dest-filename": "electron-devtools-installer-2.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+        "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+        "dest-filename": "extend-shallow-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34",
+        "sha512": "dbb1c18212718e266d224dd872f9ffe246c993fd6e66e2457ee3c49ece8b684be9bc6d5fd214de6bc96296ba2eca8f6655cd8659d70467c38ba0699200396b0b",
+        "dest-filename": "concat-stream-1.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909",
+        "sha512": "aee3cc35190ddcc1cfd5c58973d396afe4ffc433f48e15d808b7c9701b97e788617c806769098050c7c3706e0333950c581c816c963af504a9866de3b4328890",
+        "dest-filename": "pump-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d",
+        "sha512": "7102a1f22828e5052167b960dfc0d8580c4cbe3480286d00f3019256298fd3b4885042b650ef9aad244a6d1656b5e94cb4de55d07930879af23ada3f4ac85822",
+        "dest-filename": "lodash-4.17.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6",
+        "sha1": "af6ac877a25cc7f74e058894753858dfdb24fdb6",
+        "dest-filename": "array-uniq-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c",
+        "sha1": "125820e34bc842d2f2aaafafe4c2916ee32c157c",
+        "dest-filename": "readable-stream-1.0.34.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7",
+        "sha1": "7e32f75b41381291d04611f1bf14109ac00651d7",
+        "dest-filename": "q-1.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63",
+        "sha1": "168a4701756b6a7f51a12ce0c97bfa28c084ed63",
+        "dest-filename": "colors-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94",
+        "sha1": "62e203bc41766c6c28c9fc84301dab1c5310fa94",
+        "dest-filename": "string_decoder-0.10.31.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz#60fb229b997fc5a0a1fc6237421030180959d469",
+        "sha512": "9865c3833e52953c5c177854a5f0bc86b435d72840b6db944167f55a66feeb3a37c7aadbedbf6621fb90bc03cb75f0d1086446bda90158774739ad08f69fc455",
+        "dest-filename": "webpack-dev-server-3.1.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501",
+        "sha1": "c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501",
+        "dest-filename": "iferr-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064",
+        "sha512": "1f281008a50148597cc0a4190527a6332c1159c10336276f35b8c657266ede76d9f2aabdb9b88fa062cc7510e97d2ae99249bd0576059292b1c455f7f28ffbeb",
+        "dest-filename": "dotenv-6.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
+        "sha1": "3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
+        "dest-filename": "memory-fs-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a",
+        "sha512": "d14c5f42432160051a648fb1acd64ecff6ace4a80353433f7d0f5be92a64c8b6e4dc612cc038ba3c00c955a609ada76d455b11225175ccbc8ea1d6dc4c20f352",
+        "dest-filename": "dns-packet-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a",
+        "sha1": "00a9f7387556e27038eae232caa372a6a59b665a",
+        "dest-filename": "resolve-cwd-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz#818719a1ae1da325f9832446b01136eeb493cd7e",
+        "sha512": "2da60b0cd4b8486f10e56016a882607473c9ac30ebfcbbfbef9acc04551b8234f3ea3df8954ce70021dc7515aba0fbd700d3f6563ef234ae7bbe9f5e16accb59",
+        "dest-filename": "postcss-modules-extract-imports-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/default-gateway/-/default-gateway-2.7.2.tgz#b7ef339e5e024b045467af403d50348db4642d0f",
+        "sha512": "9407388bd40947460748315dcde05029f6754910c6de1b0934492ba5c65af108417e274b022953eb4043108554506aa8b05a78db928e801dee62a72742b59a7d",
+        "dest-filename": "default-gateway-2.7.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047",
+        "sha512": "ed3fc1c47d7dcdb7024daf1790c95b2b9953a355ad824162dc6bdd584c8db9ce157b1efff43a9b9e9b1fe0933275c7e3f470a0e335161532f765aea56a9839ff",
+        "dest-filename": "hosted-git-info-2.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87",
+        "sha512": "85e34f254248a82fb107a6b22c0307688ae637d1ca6bb6903bc306a8aa6f080fae25855cbd1ea5e6481dae146ec0f14753b3f9fc0d70d018c1c8f1f0a5f4c32a",
+        "dest-filename": "debug-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d",
+        "sha512": "2f31c5eb8b397213d0412d086019fd20de61de2f7c735d9ba383423bb7b4b063369655d0de9d85182e6c74434de1c4d6e3c3bdd794a1fb1f845f1ed75bdeb161",
+        "dest-filename": "tar-4.4.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656",
+        "sha512": "06f13f4f0a595f8157131c4ec59c9119042feb9d4c4b09962991aabe63dc4488c3a96b9bebb9132ae20cc78ddc659ad2fdc041cf005c3435a8171b765c4148a5",
+        "dest-filename": "setprototypeof-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278",
+        "sha512": "cd5595f19f258ac949a0e28aa9d34c381facebe5d5e56111b72f0c9ca05e160c00fb5f57263247b3644fe5dccce7b15fb48b3e8d09d14e82e259accaafab125a",
+        "dest-filename": "acorn-dynamic-import-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd",
+        "sha1": "bdb6c69ce660fadffe0b0007cc447e1b9f7282bd",
+        "dest-filename": "color-convert-0.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3",
+        "sha1": "98472870bf228132fcbdd868129bad12c3c029e3",
+        "dest-filename": "promise-inflight-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "dest-filename": "os-homedir-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9",
+        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
+        "dest-filename": "parse-json-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.38.4.tgz#67727529ffb87e7fdd78b3a84ea0d6c22bf04ec2",
+        "sha512": "5873abdd1cf6c24b715794ea9912fac283bdff0ac865e45f24f4845ce8607e02ec904e52a7601eaf4cc017b94736a5ee1ba26153ed08f486050316bbdcc4ecf7",
+        "dest-filename": "electron-builder-20.38.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942",
+        "sha1": "3d4ef870f73dde1d77f0cf9a381432444e174942",
+        "dest-filename": "registry-url-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98",
+        "sha1": "a8115c55e4a702fe4d150abd3872822a7e09fc98",
+        "dest-filename": "chalk-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d",
+        "sha1": "b5fdc08f1287ea1178628e415e25132b73646c6d",
+        "dest-filename": "signal-exit-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863",
+        "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
+        "dest-filename": "object-assign-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.4.tgz#cdd7eccfca4ed7635d47a08bf2d5d3074092e2cd",
+        "sha512": "f40ba44e20e61d71975ad5a37a66d9e4d0e656f3f6ebde44b6981b0acc426baf30ddcf3c07e6a5a9b999e0ede16785561977865b311576faa00090fc0d03c20f",
+        "dest-filename": "selfsigned-1.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+        "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+        "dest-filename": "fragment-cache-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1",
+        "sha1": "d2745701025a6c775a6c545793ed502fc0c649a1",
+        "dest-filename": "hmac-drbg-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8",
+        "sha512": "677d68503fdf26f116551d25359b5f82f56de75d85a2b09334a61c24119b3dbd5065fbdee16187f16b32efe31ebf7dffe397e13ff87042dbe0bac35d7023204b",
+        "dest-filename": "@babel-traverse-7.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb",
+        "sha1": "8771aae0799b64076b76640fca058f9c10e33ecb",
+        "dest-filename": "jsonfile-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0",
+        "sha1": "9521c76845cc2610a85203ddf080a958c2ffabc0",
+        "dest-filename": "is-glob-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f",
+        "sha512": "e53e8fe313e0a69d180c5bd25b0119e0da04dda3384014170f39956eb6829058fccc733e99b6bc4b2a81e436d95b247b9981e8e98ec1750a373280389b44de42",
+        "dest-filename": "base-0.11.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.3.tgz#aad9ce0dcb98129c753f772c0aa01360fb90fbd2",
+        "sha512": "e95aef1fbcfa8eaa8d158db4d24741e8777392033de8e6a3f6fddda867e0a7a985f9c1e6538c3240a676fd63c3455a11d09cfd2aa6da99a04dd1985d51acac51",
+        "dest-filename": "node-releases-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274",
+        "sha1": "bbe67406c79aa85c5cfec766fe5734555dfa1274",
+        "dest-filename": "os-tmpdir-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73",
+        "sha1": "7af8f303645e9bd79a272e7a14ac68bc0609da73",
+        "dest-filename": "url-parse-lax-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f",
+        "sha1": "270f076c5a72c02f5b65a47df94c5fe3a278892f",
+        "dest-filename": "builtin-modules-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29",
+        "sha512": "9ea1d49cc5e60734f4c39ef4af62692717e2483d48ce823e1c655d777699d32362de782f4388efd5db47b79546c5f236ca3e72a8898f84e2b8be6221db131b1a",
+        "dest-filename": "websocket-extensions-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9",
+        "sha512": "5a6eae92868e1898bfef7a7f725d86bcb8d323924cd64fced788ac0fbdd830bf12b6b1ffeff9511609a0f272026600f76d966f8f0086c6d30e0f7c16340bbc72",
+        "dest-filename": "atob-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328",
+        "sha512": "bf22f63b2989c666ab3bc83132bd2684286c3bd406c21ca77eebb8f8c1d3016e9ccdfabd86e98207bacaa548c377d6148833d4e26ce9caea454af382940c1b99",
+        "dest-filename": "big.js-5.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d",
+        "sha1": "590c61156b0ae2f4f0255732a158b266bc56b21d",
+        "dest-filename": "ee-first-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef",
+        "sha512": "3107171146c22ad128edb86a12ceb9eb41f27785daa2f6653bf93d57786355417fcf05bb28155d48ae2022dfdbcf04bd31b479aa86fe1798eeb19b1bd1840ad8",
+        "dest-filename": "buffer-from-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748",
+        "sha1": "8710d7af0aa626f8fffa1ce00168545263255748",
+        "dest-filename": "media-typer-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7",
+        "sha1": "2c03405c7538c39d7eb37b317022e325fb018bf7",
+        "dest-filename": "gauge-2.7.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-2.2.2.tgz#6631417d5f0e909a3d7ec26b24c8a8d1e4f96e4b",
+        "sha1": "6631417d5f0e909a3d7ec26b24c8a8d1e4f96e4b",
+        "dest-filename": "postcss-colormin-2.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8",
+        "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
+        "dest-filename": "ms-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe",
+        "sha1": "cc70d05a59f6542e43f0e685c982e14c924a9efe",
+        "dest-filename": "htmlparser2-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281",
+        "sha512": "a48484eba01b564a787c343b54707044d5f30002898f0e15c3b9d623ff90defba5cbb48d7e0617be6ea2e48805ca51c62b9b0fff11c06c1ecde3d392e2058dc9",
+        "dest-filename": "postcss-value-parser-3.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf",
+        "sha1": "8dd8bf45fc3f7f55f0e054b878f43a62614dafdf",
+        "dest-filename": "xpipe-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15",
+        "sha1": "a205383fea322b33b5ae3b18abee0dc2f356ee15",
+        "dest-filename": "latest-version-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda",
+        "sha512": "8e78f288ce9e472665d87f96f10ff32cc038f358738b47accc06815332159e66150c16e72f154d9dfbb51e0101bc26cbfbbd45af1325dc4ea5a4a1fb19edce5c",
+        "dest-filename": "domain-browser-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab",
+        "sha512": "16cdb929530f00821c8233199151c9a0a83d55c5dc0b50bcc9bf49520783bd55d8d12ff381522131bfaa56cc03220b497b60df72431263677a4ee4c4bad964e9",
+        "dest-filename": "http-proxy-middleware-0.18.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8",
+        "sha512": "39f0b6b9e99a9275ebf3b6dd2d4916a20ee762e96233d223e4751c6a3b1570c0a942b70b9adc516d515322a99c4a449e611045051c6cd85894a852432dd89e6c",
+        "dest-filename": "@babel-code-frame-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+        "sha1": "b209849203bb25df820da756e747005878521620",
+        "dest-filename": "querystring-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d",
+        "sha1": "d225ec23132e89edd38fda767472e62e65f1106d",
+        "dest-filename": "is-path-cwd-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec",
+        "sha512": "d9e8ace56a90195ee97a8a03c8b98d10f52ba6cf7e4975f973da4bdf1101fb87bd1e71ae0daee607b907c47c3809ba92f64d53da1387de688bf27f16b62615b6",
+        "dest-filename": "is-descriptor-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc",
+        "sha1": "c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc",
+        "dest-filename": "des.js-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f",
+        "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
+        "dest-filename": "is-fullwidth-code-point-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813",
+        "sha512": "31790e26abdaeb675f0b4c3ce6611ffcbb9c3cf4bfd7ed389e699130f101501fbe862893850db33ed5ff984590de6b730848c826f3d8f27bb0c57b50790c146a",
+        "dest-filename": "@babel-helper-split-export-declaration-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.5.tgz#225322d7509c2157655840bba52e46b6c2f2fe33",
+        "sha512": "3539c79d545dd899d1a8f0b4bd6fa2390594e697210db617b06d84e8331712931f51c40a72517d8267f71b764c8731bb206f638b87282f4726f85c5e5b10e99f",
+        "dest-filename": "babel-loader-8.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458",
+        "sha512": "f3b95c6d1f3e321716714890fbd7be470c7c3324763fbaa7b75e729d495b9b74d4fdf8db833e06b2f7d25034de9ad082b550aa6f865c1059723cd4e1f5b0532f",
+        "dest-filename": "randomfill-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d",
+        "sha1": "857fcabfc3397d2625b8228262e86aa7a011b05d",
+        "dest-filename": "minimist-0.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f",
+        "sha512": "17feef9324edc9cfe594e227f2859c95c076e4a7516a23c1a596038091e087f507b69813da9d9e95d420b509cbb54bdf30a3cac5b45a40cfe11e4bcb1edd559e",
+        "dest-filename": "enhanced-resolve-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/temp-file/-/temp-file-3.3.2.tgz#69b6daf1bbe23231d0a5d03844e3d96f3f531aaa",
+        "sha512": "14629c7005b432ec7d842ff66dd5087b86c946fe0ec95a3846955cba99458ab77557f628a652056e73d98dfcdb2527ffa8dbd1648441f7fe27fd1908d06ce2b9",
+        "dest-filename": "temp-file-3.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz#2e55df59e818f150a9f61b53471ebf4f0feecc65",
+        "sha512": "21885bcc960ea2989368d58c069ed18db79c501b1b9db0e778e3fce9fdeabd2d06d317f3c0d4af309a53aef8b9fd8d6053bb60d8d0207a0f1af2b098bd6f5687",
+        "dest-filename": "electron-to-chromium-1.3.84.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947",
+        "sha1": "20f1336481b083cd75337992a16971aa2d906947",
+        "dest-filename": "on-finished-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4",
+        "sha512": "e29f164324bdf1b509702bc531b746672666b0ab968d65675479c04b71458341c369156b3db922bf1d91602adef1489e983ebb46c88514b7e7e0984b0229fc57",
+        "dest-filename": "webpack-merge-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa",
+        "sha1": "cc6677695602be550ef11e8b4aa6305342b6d0aa",
+        "dest-filename": "is-finite-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.19.tgz#07e87914a55242dcda5b833d42f018d6875b595f",
+        "sha512": "db769e40a5bd2a01dee9c8ad52b1b7afd1e3797eaf96cd21ef5dd301af82c13299c0d22bfe90f60296b1605e149b7659caae1aafe4a2bf7f9f8681da23048e4b",
+        "dest-filename": "portfinder-1.0.19.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1",
+        "sha1": "7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1",
+        "dest-filename": "set-value-0.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366",
+        "sha512": "d67878e5d79e6f9a25358ede5fcd8190f3bb492c51e524982623d3ad3745515630025f0228c03937d3e34d89078918e2b15731710d475dd2e1c76ab1c49ccb35",
+        "dest-filename": "nice-try-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz#c7b6bb8105f84039511a2b39ce494f193818a32a",
+        "sha512": "eebd6a5cb9a28250bec0f3641ae5c2be499a97212cb4a57072e79944fd86342d8f02fc5b2d8c0b2cfaf5e2b71d25a13852d1f140a7c592e0c5baff758a9aaf5e",
+        "dest-filename": "@webassemblyjs-helper-api-error-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
+        "sha1": "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
+        "dest-filename": "source-map-0.5.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz#4eb8db16f972f8abb5062c161b8b115546ade08b",
+        "sha512": "9b8f18d25321adb5c4267554698972dbd8d15db43792cc4fad2d5383cb7e307ab35e1b41600bc8e757ae3816a802564b3c7b22798f573d531ff346b9c7470f70",
+        "dest-filename": "@babel-plugin-transform-unicode-regex-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03",
+        "sha512": "c5c8a72f702e0c993b552cec1e06fd0efbc85dac816da76d319e0714fc7cad4b336d6d4cb8d325c18542e33cc267a7b5b2a6699cd4b964560e857a80dfd4fb2d",
+        "dest-filename": "js-base64-2.4.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23",
+        "sha512": "3168a4825f67f4cdf0f9ba6c6371def0bfb0f5e17ddf7f31465f0800ee6f8838b3c12cf3885132533a36c6bae5a01eb80036d37fcb80f2f46aaadb434ce99c72",
+        "dest-filename": "micromatch-3.1.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39",
+        "sha1": "9a34410e4f4e3da23dea375be5be70f24778ec39",
+        "dest-filename": "array-union-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998",
+        "sha1": "ed0317c322064f79466c02966bddb605ab37d998",
+        "dest-filename": "ansi-regex-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a",
+        "sha1": "e86b819c602cf8821ad637413698f1dec021847a",
+        "dest-filename": "ajv-keywords-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff",
+        "sha1": "925d2601d39ac485e091cf0da5c6e694dc3dcaff",
+        "dest-filename": "requires-port-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0",
+        "sha1": "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0",
+        "dest-filename": "dashdash-1.14.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd",
+        "sha512": "fe6ad1a1df31aa903e20748bc86090dacf123c78820c47902527a9d63a8b61e1140a53851b642c87ee0553a1bd55eaa9667196fd2bbc2d019ce182a78b9ad849",
+        "dest-filename": "through2-2.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49",
+        "sha512": "e051be4521bd0cbeee130454657667dd24b7e038833dfccfd153a2130b545a513e011d84220fa14b2beb2205147e176047f52401e5b640781e3fe856ad7b3b8d",
+        "dest-filename": "cliui-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821",
+        "sha1": "1eade7acc012034ad84e2396767ead9fa5495821",
+        "dest-filename": "json5-0.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470",
+        "sha512": "e541989cc48b444d5daaa670ba0fb52c84a9038d371f39527ec83a3fd55753a4c18dc48778d970e03c43c7b2e0a45fa2299a0e1bffaeceaa111d375c52989936",
+        "dest-filename": "@babel-plugin-syntax-json-strings-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59",
+        "sha1": "ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59",
+        "dest-filename": "encodeurl-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80",
+        "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
+        "dest-filename": "for-in-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7",
+        "sha1": "3d8cadd90d976569fa835ab1f8e4b23a105605a7",
+        "dest-filename": "fresh-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.2.0.tgz#50a2756a9a128ab9dcbe087e2724c512e3d0ccd1",
+        "sha512": "8b54117398f2e2c1e6f580466fa02b039494d660eb739c2eda69e6debf603e79be2d56610466e94c22aa017caf5784c91e7051dd869ac30fbd6f70f245971fc3",
+        "dest-filename": "read-config-file-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz#82a9bce45b95441f617a24011dc89d12da7f4ee6",
+        "sha512": "98ad80f2e72acf5aa1addaa34bd54c2037c8bef4f6b61ac4b084336da4dd739405ce10e342fd829092797fa05722481b99aa1ac77cc1af6472bd5ffccdea1467",
+        "dest-filename": "@babel-plugin-transform-modules-amd-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13",
+        "sha1": "0dee3fed31fcd469618ce7342099fc1afa0bdb13",
+        "dest-filename": "estraverse-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/colormin/-/colormin-1.1.2.tgz#ea2f7420a72b96881a38aae59ec124a6f7298133",
+        "sha1": "ea2f7420a72b96881a38aae59ec124a6f7298133",
+        "dest-filename": "colormin-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a",
+        "sha512": "2e07765dc27f363130fbbb45bdf2b13b3098299b1d72de6573343665a418f038f3ee97c00f719ba7cc92256b6b78823fbc394c566c706baa4799dc48620b6d0e",
+        "dest-filename": "domutils-1.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz#c4245b6de242cb50a2cc950174fdbf65c78d7813",
+        "sha512": "9b9be402cb89df642991d9033943c64a5b6b83c0ae937281c7862b980190c0264f45d5075f11b8a6120ebaec9c2de98716bef8b162fd5ad86ab2ce1fcddcd2c2",
+        "dest-filename": "@webassemblyjs-wast-printer-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dotenv/-/dotenv-6.1.0.tgz#9853b6ca98292acb7dec67a95018fa40bccff42c",
+        "sha512": "fef7839f6ced811941ee02a61378bd7fa0a60c8c97032e9de6706afb084ef522d7f99b35b1712014b3e2f9a4ae5aa52ebac31f6e2f387d3f23df87ecd4769853",
+        "dest-filename": "dotenv-6.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz#981d57d29ddcb33e7b1dfe1fd43b8649f933ca1d",
+        "sha1": "981d57d29ddcb33e7b1dfe1fd43b8649f933ca1d",
+        "dest-filename": "postcss-unique-selectors-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56",
+        "sha512": "7f62d9318975173bbb61204a83e46844e7a5a4e68dadc1a613d019b9b7837eb08489ae3cde85b8308e15c8577954d1c8810ffbaa6d48d305072b57899e7db2db",
+        "dest-filename": "entities-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.1.tgz#fa4b79fa47fd3def5e3b159825161c0a519c9427",
+        "sha1": "fa4b79fa47fd3def5e3b159825161c0a519c9427",
+        "dest-filename": "ipaddr.js-1.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "sha1": "3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "dest-filename": "console-control-strings-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0",
+        "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
+        "dest-filename": "load-json-file-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136",
+        "sha512": "8f1c334292d08d29965e0c1a09913d373fa09401b4d721754275a06e11b01c8e40e85448118e8856ab478487a91ea23bfe4c84c9011a8010b998110594862f76",
+        "dest-filename": "asn1-0.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz#ad2ce071373b943b3d930a3fa59a358c28d6f1f3",
+        "sha1": "ad2ce071373b943b3d930a3fa59a358c28d6f1f3",
+        "dest-filename": "postcss-minify-params-1.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.1.4.tgz#50b5d4ffc4575276573c4eedb8780812a8419f01",
+        "sha512": "15261ba779722a3ca3dc4edf325eab62f51d5f41415da96e1aa945a18112590972513abc47ec29d2b905c68605a999470afb145c68f22662d04a75d3a1884e48",
+        "dest-filename": "mdn-data-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+        "sha512": "c891d5404872a8f2d44e0b7d07cdcf5eee96debc7832fbc7bd252f4e8a20a70a060ce510fb20eb4741d1a2dfb23827423bbbb8857de959fb7a91604172a87450",
+        "dest-filename": "minimatch-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3",
+        "sha512": "a9ed637e6d4c83b36afcd4a1e97136e203d744e115b161f10b52c8c7ffd73650fd8b0ed86501a364d8d837bc466841ba88a740f04b4d156e91d208e7557a7ec1",
+        "dest-filename": "supports-color-6.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e",
+        "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
+        "dest-filename": "to-fast-properties-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177",
+        "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
+        "dest-filename": "has-value-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988",
+        "sha1": "0258eae4d3d0c0974de1c169188ef0051d1d1988",
+        "dest-filename": "escape-html-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13",
+        "sha512": "2e1cfc4cb6989f1abfd8e6ea1c3aa5f1d5fc0898bdee81f1ae351c62dcca6dbca43ed556f5607ea68c48f8d336508cec32034265321fd00430b232b9c8c02a67",
+        "dest-filename": "yargs-12.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz#e75269b4b7889ec3a332cd0d0c8cff8fed0dc6f3",
+        "sha512": "72854ed80cafee0d2a7436eb36269d1386d4ee5bc277d1f9dfd9b680c927c958e331dc05fe208e33b47e13c3e49eda2a2e496d3b4ae4fb76b1869a7fd2febc55",
+        "dest-filename": "@babel-plugin-transform-destructuring-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4",
+        "sha1": "c814903e45623371a0477b40109aaafbeeaddbb4",
+        "dest-filename": "cssesc-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f",
+        "sha1": "c36aeccba563b89ceb556f3690f0b1d9e3547f7f",
+        "dest-filename": "ansi-align-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+        "dest-filename": "path-exists-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe",
+        "sha1": "b432dd3358b634cf75e1e4664368240533c1ddbe",
+        "dest-filename": "ansi-styles-2.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.0.tgz#ecf021fa108fd17dfb5e6b383f2dd233e31ffc59",
+        "sha1": "ecf021fa108fd17dfb5e6b383f2dd233e31ffc59",
+        "dest-filename": "ajv-errors-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+        "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+        "dest-filename": "unset-value-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f",
+        "sha1": "7c1d16d679a1bbe59ca02cacecfb011e201f5a1f",
+        "dest-filename": "camelcase-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c",
+        "sha512": "59e04e763bbc4a7ccf379bd3509631614c4b797a426953f98b97b42c5f1f83b58e445d9677bc055ffa64d2d61993bb3c4fe27b54bcb40dae89d7ec024f402d1e",
+        "dest-filename": "nth-check-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad",
+        "sha1": "441b6d4d346798f1b4e49e8920adfba0e543f9ad",
+        "dest-filename": "sort-keys-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd",
+        "sha1": "b5d454dc2199ae225699f3467e5a07f3b955bafd",
+        "dest-filename": "has-flag-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32",
+        "sha512": "dd461c2548fd92f48b6cb6d421f413ab3732e555fb19167f0820eb9ce699a2b145334d5a5e9d7e189c2e1465783430e8012fa6394c8770ee940ff45fa8e92cdd",
+        "dest-filename": "@babel-helper-annotate-as-pure-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
+        "sha512": "edd147366a9e15212dd9906c0ab8a8aca9e7dd9da98fe7ddf64988e90a16c38fff0cbfa270405f73453ba890a2b2aad3b0a4e3c387cd172da95bd3aa4ad0fce2",
+        "dest-filename": "error-ex-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239",
+        "sha1": "d3768d69b1e7d82e5ce050fff5b453bea12a9239",
+        "dest-filename": "serve-index-1.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz#7678ce75169f0877b8eb2235538c074268dd01ae",
+        "sha512": "055ddbc3a332507d6222c1a15e538aeac5e19926ab663b49fef3220fd74d9a963c4171454138feeaff76a5c7f2d62a9af037807c9170a3172b4bf4d465d6bab3",
+        "dest-filename": "@babel-plugin-transform-modules-umd-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
+        "sha512": "dedeab553a1ea197d848677c6282c54760c992242b22252b19c8ef157da60f0ddb9fa9363adc073744cd08b6c13bec3ca93be29a10e4bfe2d2b1c6c9635bc4eb",
+        "dest-filename": "get-caller-file-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38",
+        "sha512": "1d2f1b67da31eb4c8224b1fdb27069230bfda5850091cb8b852035a1eae8d54079cbd6a2429440f32d9ec7de3900eb4264bd652437889371b92ed86cc08e3a2f",
+        "dest-filename": "is-symbol-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e",
+        "sha1": "f49be6b487894ddc40dcc94a322f611092e00d5e",
+        "dest-filename": "range-parser-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa",
+        "sha1": "9d9e793165ce017a00f00418c43f942a7b1d11fa",
+        "dest-filename": "has-flag-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a",
+        "sha512": "1f125d616ab53132106c9de7c3472ab2c1e84cd536ebb2a5ac3b866755989710d2b54b4a52139a266875d76fd36661f1c547ee26a3d748e9bbb43c9ab3439221",
+        "dest-filename": "which-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+        "sha1": "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+        "dest-filename": "wrappy-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz#3122d48dcc6c9456ed982debe16c8f37101df39b",
+        "sha512": "3329ee7abbddca53cf8778b1fa62999684dc2f4e8ff2d7a7347decc7ab34a84f122d1e837709df800ec773d35261ea1bda3ad6e55aa5e86565b10cca4026b5df",
+        "dest-filename": "@webassemblyjs-helper-buffer-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz#5dbda11373703f83cfb4a3ea3881d8d75ff5e6e1",
+        "sha1": "5dbda11373703f83cfb4a3ea3881d8d75ff5e6e1",
+        "dest-filename": "postcss-minify-gradients-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b",
+        "sha512": "bf73179d901cbe7cb091350466898801cb657bb4575de79d391df5c3097b565ca85cee108bd6abbd27a73505a77b54dc4708422f51f02c8db56c4a9da63f3fac",
+        "dest-filename": "iconv-lite-0.4.24.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-locale/-/os-locale-3.0.1.tgz#3b014fbf01d87f60a1e5348d80fe870dc82c4620",
+        "sha512": "ee0e5eedd9973edcdc3f86e0b19f22c4356a03ba1662e133e25392ba3796ca588f6a2e207d50e2148730060dda1823e799219fcce2932b771c3e7d022afdc307",
+        "dest-filename": "os-locale-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43",
+        "sha512": "d4c92b64dbd64ca09a8a06e7f96d797a5ab6041fcbdb69eaad26390ca968dd7ebebdc9499bc05be5d8d72419845fa7d2dfecc287f1785412b96762b126de2cd9",
+        "dest-filename": "end-of-stream-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0",
+        "sha512": "298f45ae68abaa5f755f64208ebcb459de18f984ddadd661792f13170be46cb59ffc6e4a3490c287aa4a2f939972d116e3ed0169ae6274ad9942e10b4703f39d",
+        "dest-filename": "uri-js-4.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44",
+        "sha1": "ba1a8f1af2a0fc39650f5c850367704122063b44",
+        "dest-filename": "has-symbols-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82",
+        "sha1": "073c697546ce0780ce23be4a28e293e40bc30c82",
+        "dest-filename": "dom-serializer-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz#5d3cc11e8d5ddd752aa64c9148d0db6cb79fd190",
+        "sha512": "9ed40f47aab5fcd2aea61972e3df908908933743badee3b08dd0fa761223496048e7196b6d4161ef6d13229cc18699eb2dfbf6b4d1ff057bcb21a6f5f81008d3",
+        "dest-filename": "@babel-plugin-transform-block-scoped-functions-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e",
+        "sha1": "a4301d389b6a43f9b67ff3ca11a3f6637e360e9e",
+        "dest-filename": "bcrypt-pbkdf-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+        "sha1": "e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+        "dest-filename": "isexe-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz#a4f2f4fab6e4fe002f0aed000478cdf52f9ba60e",
+        "sha1": "a4f2f4fab6e4fe002f0aed000478cdf52f9ba60e",
+        "dest-filename": "postcss-message-helpers-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502",
+        "sha1": "97e801aa052df02454de46b02bf621642cdc8502",
+        "dest-filename": "expand-tilde-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec",
+        "sha512": "7e5e6ce76948e5a84a09eae7cf323200fd100196c6228bed5471b0a5cbb526bfc4a732d50c8da6c88487c06a8aee6f2e405ba05564ab6f11fb5e7846b6f11cf8",
+        "dest-filename": "p-limit-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36",
+        "sha512": "96b79ec0b2bf0658219b1b5f1f7e986158358bc20071ee1323ba1aa3be48d60db8e7ee8172da935508813f761427d0ba0d039726691847d5fd7c22ed08e25ce7",
+        "dest-filename": "rimraf-2.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+        "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+        "dest-filename": "copy-descriptor-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf",
+        "sha512": "eb844107ef9f20e0173f0dcff5ccbcf6a7cc96f6445d992aa89923aaa5c8bf33f97b34598d6fa53d68f0df9517ff712150f1586e0e44478258803c38d34eff0d",
+        "dest-filename": "esrecurse-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+        "sha1": "a88c02535791f02ed37c76a1b9ea9773c833f8c2",
+        "dest-filename": "is-extglob-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545",
+        "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
+        "dest-filename": "decode-uri-component-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d",
+        "sha512": "1411c45ba25fe5307d30606051403d5c79136e35d87c0523638dc008c7e674c4479e2ca83078c78f30f9d0e2bc2c60d6430a78ad612c22ae6412aabbaef20cd6",
+        "dest-filename": "ajv-6.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d",
+        "sha1": "b39e7f1da6eb0a75ba9c17324b34753c47e0654d",
+        "dest-filename": "dns-equal-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80",
+        "sha1": "0dfd98f5a9111716dd535dda6492f67bf3d25a80",
+        "dest-filename": "is-installed-globally-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b",
+        "sha1": "6309f4e0e5fa913ec1c69307ae364b4b377c9e7b",
+        "dest-filename": "performance-now-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz#a1e454b5995560a9c1e0d537dfc15061fd2687e1",
+        "sha512": "28a602a0669101ff9c907f2010bdc91d468557234729edc048db19f80964b601debefc468a0a08b6dac425bf2228dd3743b11ace5bf5b3a731d81d9c43725a6f",
+        "dest-filename": "@babel-plugin-transform-sticky-regex-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz#9bbba942f22375686a6fb759afcd7ac9c45da1a8",
+        "sha512": "53f283629edf800657e4a3dfab834eba92bf0668437392a3cb6188aacb4c86fbdd25170447f914b0c4e1a567913fc04c9f82d768a8524e080824f39e607c0848",
+        "dest-filename": "@webassemblyjs-wasm-gen-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50",
+        "sha512": "ed738c9f3f189f1d601a8ff787257d96860d3d633de231b7fb74f763cb6c7d2b2d166113984342314fc0ff38fc2f26a3d6592011ea4a7a9bddeb6e34b4146f97",
+        "dest-filename": "execa-0.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d",
+        "sha1": "1f16e4aa22b04d1336b66188a66af3c600c3a66d",
+        "dest-filename": "is-wsl-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz#c4f1933f5991d5145e9cfad1dfd848ea1727f404",
+        "sha512": "57acb4b9a510ad03d752b9a3fa182792cf2f6b62f4cdc67299e53b4ed58481d44b36471e69f29711dbafed0ce0400138953facbb0a281bd742ecb16175101b55",
+        "dest-filename": "@babel-plugin-transform-modules-commonjs-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz#135d81edb68a081e55e56ec48541ece8065c38f5",
+        "sha512": "9a0623de309cc6e83a294717e0e068389cf708caf045f4042cf439e7ad05ef4610501641eee69cf5fa9a59a98a4758965331a22b6b74ca0ce34d27199d5cfbe6",
+        "dest-filename": "@babel-plugin-proposal-optional-catch-binding-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8",
+        "sha512": "71974417baf881f448abb7b35fd2744fe91098934eb9bef57566e00175470dcb7cd1328fe0c0844ed650df5c72bf7f14c20ce458f605fd773481ee79756f59f7",
+        "dest-filename": "http-parser-js-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+        "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
+        "dest-filename": "fs.realpath-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1",
+        "sha1": "f877d5bf648c97e5aa542fadc16d6a259b9c11a1",
+        "dest-filename": "whet.extend-0.9.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz#b9abf27b88ac188158a5eb12abcae20263b91932",
+        "sha1": "b9abf27b88ac188158a5eb12abcae20263b91932",
+        "dest-filename": "postcss-discard-duplicates-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c",
+        "sha512": "1a982f1c7a1c191c909bbe1be85584659551ae81ca135234fc14e3026c926a884af9c527fa16696ea5e4737296816de041892a7107a3df916885c4f415196445",
+        "dest-filename": "plist-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369",
+        "sha512": "38452595c568c9d04718dd73f38c9f4038a69f9f2964d34d5e06651d749ba3132516f808e8c5d25a958aa4546b6bb1f51f1a558474e4ae085f456e3d93aca37a",
+        "dest-filename": "mime-2.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5",
+        "sha1": "53ecf699ffcbcb39637691ab13baf160819766e5",
+        "dest-filename": "del-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782",
+        "sha1": "dae46a9d78fbe25292258cc1e780a41d95c03782",
+        "dest-filename": "flatten-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818",
+        "sha512": "8c3acd9d7587778a07893667c7f646ee0b544d5a7e8027134caafc2f41e3970a6144e116dfe1e29be229bc2fb17091057a06a988c67265ed360b2b8e9d199b9d",
+        "dest-filename": "unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db",
+        "sha512": "1d28f2046e4dd4d9f3eed176f8eec0f57521ca3aeeef5fdfc2035bee822c1151d1d164a17ecdad212fc4c922e08937bdf1a38ad7c60394c5e9ce309763f9fd9a",
+        "dest-filename": "compression-1.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72",
+        "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
+        "dest-filename": "urix-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c",
+        "sha512": "b3ab5fb1a41a422dc935c8811fab2156a103be11aeb744945ebdf56a0f0f77c0416d55657067d68693e610ea0ce912794c585bca9bdfe72c91c3f5575b52225a",
+        "dest-filename": "is-ci-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d",
+        "sha512": "16dc8e9d637fc021d355738cc2f4afdba77e928e6f5a52030face8509ecb5bcbe1f99042f107658ef7913fe72b36bb41c22a04516cbfe1d32d6c18c0e22a0d96",
+        "dest-filename": "snapdragon-0.8.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80",
+        "sha1": "8e2d48348742121b4a8218b7a137e9a52049dc80",
+        "dest-filename": "indent-string-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3",
+        "sha512": "f5eb22125bf506b668237ac20ee3ae2820516ee0291866833d07e349f946c5dcb8a32cea821c6eea4944924548bc18def85174057f5ca04bfc2aa5ba5ffee78f",
+        "dest-filename": "raw-body-2.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c",
+        "sha1": "04e6926f662895354f3dd015203633b857297e2c",
+        "dest-filename": "sprintf-js-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9",
+        "sha1": "0bd76704258be829b2398bb50e4b62d1a166b0b9",
+        "dest-filename": "browserslist-1.7.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.3.tgz#a0ec7bd9055c4282f790c3c82f4e28db3b31b229",
+        "sha512": "8e2e89e5e9db3321911c802400ebb759d57c9e082abe228210ab5770ea9fa61659b50ae61cac9c7f29c9d95ede54f500e0d849e95ed67f84e619b4f0284f41ea",
+        "dest-filename": "multicast-dns-6.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c",
+        "sha1": "9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c",
+        "dest-filename": "p-defer-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8",
+        "sha1": "b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8",
+        "dest-filename": "aws-sign2-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713",
+        "sha1": "9f95710f50a267947b2ccc124741c1028427e713",
+        "dest-filename": "utils-merge-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c",
+        "sha512": "648cd1a4b26b3a3ee38cfda6880b60a887e6cdbc5ae193abe6325ceb4d73925b1f131f684f39a68f69d5a483d1a4d9514c887c95cd64c9588863b0564863662b",
+        "dest-filename": "detect-node-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c",
+        "sha512": "6c37b8c4a3616f42c8ec8bd91e2035de47dfd0a11f6865ff1efe25300f7eed311ceb784c36f7caa3a645a5784ab84a7e208feadf919ce0da0c7836726946e3f7",
+        "dest-filename": "@babel-plugin-syntax-optional-catch-binding-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.1.6.tgz#0adb330c3a281348a190263aceb540e10f04bcce",
+        "sha512": "0cc894ce563d0d28d5b0eca526cb312c74a08fab5633d3d11493865bf45a3a095538af67cd3c6838c7d37d141719409443f1e6946d9e7f00be5ea5042796b2e3",
+        "dest-filename": "@babel-types-7.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+        "sha1": "132ee63d2ec5565c557e20f4c22df9aca686b10d",
+        "dest-filename": "xmlbuilder-9.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe",
+        "sha1": "dbf743c6c14992593c655568cb66ed32c0122ebe",
+        "dest-filename": "global-prefix-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "dest-filename": "path-is-absolute-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db",
+        "sha1": "66266ee5f9bdb9940a4e4514cafb43bb71e5c9db",
+        "dest-filename": "stream-browserify-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+        "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+        "dest-filename": "get-value-2.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea",
+        "sha1": "988df33feab191ef799a61369dd76c17adf957ea",
+        "dest-filename": "currently-unhandled-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f",
+        "sha1": "5b46f80147edee578870f086d04821cf998e551f",
+        "dest-filename": "loud-rejection-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38",
+        "sha1": "f0efe18c4f56e4f40afc7e06c719fd5ee6188f38",
+        "dest-filename": "faye-websocket-0.11.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44",
+        "sha1": "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44",
+        "dest-filename": "is-stream-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656",
+        "sha512": "9b98671d391c56c3dfab1dc02a5cadb483dbec9f97ca41ef24fd81f5b6438e584b22812ae17a0aeb8560edba199555982ba2d463de1d60f104ecb87466464a71",
+        "dest-filename": "is-accessor-descriptor-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-plugin-component/-/babel-plugin-component-1.1.1.tgz#9b023a23ff5c9aae0fd56c5a18b9cab8c4d45eea",
+        "sha512": "594c3cf3b9097f6187f34360fd931cb4a679d7589a98736a3e177db8aa35e32ce2b2f57b5add4472422b6fca2afee0b3dc1dcfa405bb5df97b0244cb0d84fa6a",
+        "dest-filename": "babel-plugin-component-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d",
+        "sha1": "e7dee66e35d6fc16f710fe91d5cf69f70f08911d",
+        "dest-filename": "jsesc-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0",
+        "sha1": "cc33d24d525e099a5388c0336c6e32b9160609e0",
+        "dest-filename": "path-dirname-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73",
+        "sha1": "ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73",
+        "dest-filename": "camel-case-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz#479b46dc0c5ca3dc7fa5270851836b9ec7152f64",
+        "sha512": "2a2ec965aedf7f53771083253e719365f50c7baf451708903e75525c2f669e7de3a33091058231899778e3224e57602669b3a8e2a15ff2cd1d0bffa5c1e1bbfb",
+        "dest-filename": "postcss-modules-values-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.3.tgz#bb97b200ef00801d94c317e29dc6ed39e31c5edc",
+        "sha512": "a6309fdc1624faebf765c3f3115334045bcef54c39f139a5ad4d281b9b53aebf4a722777fa474ac5aa47f028dd62655ada73b9c0ea199f6addbd9c763ca8ffc6",
+        "dest-filename": "lazy-val-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e",
+        "sha1": "9c9456989e9f6588017b0434d56097675c3da05e",
+        "dest-filename": "p-is-promise-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe",
+        "sha512": "19af1cf0d8c0029e3a06be3ed286765b1242c08cf03fad06ab560f814fb7f4f893571c9e77f88a13fcf2648ebe5255581f94383da41d1e171e80814f65351fa1",
+        "dest-filename": "serialize-javascript-1.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+        "sha1": "c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+        "dest-filename": "ansi-regex-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048",
+        "sha1": "d32815404d689699f85a4ea4fa8755dd13a96048",
+        "dest-filename": "bytes-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27",
+        "sha512": "4d1d3f37434309c5085046ea57a7423be2e9b6699240543babbd257dc101e1446c8c3d04d47ce272bc141fe6a9e81010da38425fd43852a672e308a5ba35a592",
+        "dest-filename": "@babel-helper-regex-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d",
+        "sha512": "261065d2c9178d43c2147ef1eb1eb5810c6b2b25ecc41e6072078f2d90b07f20861ac4c848ca0878e6dbaef55e3fa5e6c9ab9dc384d3e37a95d86cfe8b2776a1",
+        "dest-filename": "fs-minipass-1.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4",
+        "sha1": "5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4",
+        "dest-filename": "union-value-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz#d874d722e51e62ac202476935d649c802fa0e209",
+        "sha512": "2717c3e435fc620ab83ef5c3b9cab433eb1b50503b04902ffc61a5f484e8bea13e89d197f89dd04b3258cfe2f04262fb7c2dd1b3ebadbd6a09c436faa660b4aa",
+        "dest-filename": "@webassemblyjs-helper-module-context-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f",
+        "sha512": "d59ac8441bf6b7419295cc15a10e958122e92e088dfc5550533b7dce7c68eefd8ebf88c9aecf1163cb6fd30bc3985377a8874c296ae630c5bac99d06d7d31f1a",
+        "dest-filename": "@babel-plugin-syntax-async-generators-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e",
+        "sha512": "b8121c225dc887a3e17b75c72b536a6e824b7467f0af550dde4eb0483d5d66998fb0891bf0018d6d9609d5f38193cdf8f86c72f2ba5f0f1ad2e972c4319318da",
+        "dest-filename": "spdx-license-ids-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e",
+        "sha1": "da309cc263df15994c688ca902179ca3c7cd7c7e",
+        "dest-filename": "clone-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c",
+        "sha512": "e3face120f3a8e2bed3d378e5144fad6324ed586b54eb47f3a4a824990f2abce16261dcbbae8a984160937e7e6e71b9f224e17005704c2d7bff16cc2f087ffd6",
+        "dest-filename": "buffer-indexof-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+        "sha1": "b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+        "dest-filename": "core-util-is-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38",
+        "sha1": "4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38",
+        "dest-filename": "cssnano-3.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+        "sha512": "a39468cbab4d1b848bfc53a408037a4738e26a4652db944b605adc32db49a9b75df015ab9c0f9f1b3e7b88de4f6f4ea9bc11af979810d01e3c74996c957be84e",
+        "dest-filename": "argparse-1.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa",
+        "sha1": "e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa",
+        "dest-filename": "loglevel-1.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828",
+        "sha512": "6eb5a5f72eaf381d7160f65ca5975edcdf730c1c974e8b0078c0e8e29d70ce8e9430e5f8bee981f933f5459efab1f13a31debc4343494ab13f81b7b3778525fb",
+        "dest-filename": "combined-stream-1.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92",
+        "sha1": "a94c2224ebcac04782a0d9035521f24735b7ec92",
+        "dest-filename": "har-schema-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e",
+        "sha1": "a230f64f568310e1498009940790ec99545bca7e",
+        "dest-filename": "crypto-random-string-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz#537fa13f6f1674df745b0c00ec8fe4e99681c8f6",
+        "sha512": "3514297c7ac9d66b021ed2a36f3b3d61c3262593a0ea640c986441fa16da984746e4f3696929bde76ef9543f760ef24abb2974b36b0588398c67e1279efb9fa8",
+        "dest-filename": "@babel-helper-explode-assignable-expression-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9",
+        "sha512": "e3cdd72cbc53548c162b7413acc191a947d4a683acff485b42b976a33e09d2901c9b70376eef38c314c5a86aa42737b008b74c137f3124b240c410017d04fcb1",
+        "dest-filename": "fastparse-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6",
+        "sha1": "6d5b934a456993b23d37f40a382d6f1666a8e5c6",
+        "dest-filename": "parse-passwd-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5",
+        "sha512": "ceb5234517b56e95cab17d6a0093498ea655884ad5bb212431346bc2ee2e778b1b4ed201466b5a603ac799c1a09ab6ec5b73077e6b487febc9ba68109fe3eb5e",
+        "dest-filename": "postcss-5.2.18.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f",
+        "sha512": "73011255794edeeae5f585a5156fd303d72c842121b6eec8289fe9e6ca09fe01a98fbbdbbc5ac063f7888a843a0f0db72a3661620888a3c1ceb359d0dafaffa1",
+        "dest-filename": "use-3.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
+        "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
+        "dest-filename": "array-unique-0.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5",
+        "sha1": "f5d260292b660e084eff4cdbc9f08ad3247448b5",
+        "dest-filename": "deep-equal-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75",
+        "sha512": "af9a7db3126362702b2e339ba63038c6ee44288dc2b8a1e42573214fb9306e95322050f59f93cc02ca0fbd69efb5988dcfb2e39180d166177b16523478c8a310",
+        "dest-filename": "is-callable-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+        "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+        "dest-filename": "to-object-path-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b",
+        "sha1": "86a763f58ee4d7c2f6b102e4764050de7ed90c6b",
+        "dest-filename": "regexpu-core-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7",
+        "sha512": "7e4a73f1e8dd9c4306decdfbc062f4ee24810e0f7d3bd0f9c9f944f5118d1f7851771f523b061f9c661d64e508662b4df04f84daf92adcc50c60cbcf625e5964",
+        "dest-filename": "loader-utils-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9",
+        "sha1": "b47df53493ef911df75731e70a9ded0189db40c9",
+        "dest-filename": "fs-write-stream-atomic-1.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
+        "sha1": "89b4d199ab2bee49de164ea02b89ce462d71b767",
+        "dest-filename": "balanced-match-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d",
+        "sha1": "befe89fafd5b3dace5ccce51b76b81514be00e3d",
+        "dest-filename": "postcss-discard-comments-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90",
+        "sha1": "f9437788606c3c9acee16ffe8d8b16297f27bb90",
+        "dest-filename": "postcss-selector-parser-2.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-4.1.0.tgz#33eff662a5c39c0c2061170cc003c5120743fff0",
+        "sha512": "02c9c164dddaf3f25c36df8a3e4186383680e1cee5dd6e7e5a978a80649bb2d48bc6a5ad4d7a9dd6278918143c2050ad460f039a6294712908914734038a7760",
+        "dest-filename": "7zip-bin-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34",
+        "sha1": "11a060568b67339444033d0125a61a20d564fb34",
+        "dest-filename": "is-retry-allowed-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005",
+        "sha1": "9528f442dab1b2284e58b4379bb194e22e0c4005",
+        "dest-filename": "yauzl-2.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52",
+        "sha512": "1635754535b8f04ec258cede13f276349bc010455e92d79c0c15411391e1de733525dd24be11ed5faf0faf7c6c0dff39ef1b77638024c1550b2b5564bbad9a69",
+        "dest-filename": "is-path-in-cwd-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640",
+        "sha1": "1b33792e11e914a2fd6d6ed6447464444e5fa640",
+        "dest-filename": "cyclist-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64",
+        "sha1": "5ae68177f192d4456269d108afa93ff8743f4f64",
+        "dest-filename": "tweetnacl-0.14.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f",
+        "sha512": "22d7d87cf2e458752372440293cc42f8bc3180af0d61c5f2c068a02604b038ff18da2c964f87f6bec667a0e5d34dba3ea39c97988509e209f9e77f123b94b780",
+        "dest-filename": "bn.js-4.11.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8",
+        "sha512": "1597643410ea0511ca4363046d20b5ef19cf14e859c5e27660649faf604a7f7b2e8c6e3d41eddb07eac60b041f21a03b5879c67869128a35f816e04276bcd6fe",
+        "dest-filename": "@xtuc-long-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "sha1": "e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "dest-filename": "is-typedarray-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3",
+        "sha512": "f0226c6ca3ad11b9c9b13cafe8b13a9ba64a9e2a8c8855a69bdb116e8a5b906b3780c3cf7dddc587c888038624bf93206936ea1ebe016a818b24b64d86cad6d5",
+        "dest-filename": "uglify-js-3.4.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92",
+        "sha1": "be2c005fda32e0b29af1f05d7c4b33214c701f92",
+        "dest-filename": "move-concurrently-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48",
+        "sha512": "fbb0875ea1aeb29527fd297968eec46b4c56180b444cf5cd4808c7a38f097cb74f59c327837dd77b8ce716f4307aa73fbb3939cd2388dc7e760989e309f6f984",
+        "dest-filename": "browserify-aes-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.3.0.tgz#12fc9d6cb663da5739d3dc5fb6e8687da95cb177",
+        "sha512": "47d8f11338679eb7712c23659f4c60e6e187a8c9e484f493cd4647d9e5dc474dd2fce9fd62fa2adb0c946482d1521642355bb63e6c16568cae88fcfcb61f336e",
+        "dest-filename": "sockjs-client-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d",
+        "sha1": "19d386a1d9edc6e7c1c85d388aedbcc56d33602d",
+        "dest-filename": "async-each-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz#4b58edb56641eba7c8474ab3526cafd7bbdecb69",
+        "sha1": "4b58edb56641eba7c8474ab3526cafd7bbdecb69",
+        "dest-filename": "postcss-minify-font-values-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781",
+        "sha512": "439b2b93fe2f0cce78589b098a8dd7367e8adac086f8243c1b95b3e9b661459a007bff93c63581fc69450276046e461594e37d14c93f7c4de1d912e93d7a3895",
+        "dest-filename": "tough-cookie-2.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de",
+        "sha1": "633c2c83e3da42a502f52466022480f4208261de",
+        "dest-filename": "inherits-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+        "dest-filename": "find-up-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz#1132fecc9026fd90f0ecedac5cbff75d1fb45890",
+        "sha512": "43d2327345fd74ff5b02c62c900549fe19886594307ffdd2cb8c4201980be5c5248d999464bb789791e96d24ff3dd8239f7bbaa44eeee4e7467756a983346e8c",
+        "dest-filename": "webpack-dev-middleware-3.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34",
+        "sha512": "aa743b81533118dc6c88be2512e2707bf4e8f149caedf02799b184107f11a4ba2eb8a6de126d2585b415148acd4ae07e1bbb55ac0955b198044d3e679637fe23",
+        "dest-filename": "source-list-map-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622",
+        "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
+        "dest-filename": "expand-brackets-2.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee",
+        "sha1": "5529a4d67654134edcc5266656835b0f851afcee",
+        "dest-filename": "methods-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c",
+        "sha512": "2f8428875e6f4df9edb27e0fd73aa71ee946d0b75782348ed37e5f12976da7a6315e1313e7543abe0339958746ff95f73234be93f63d5f0e1214263d224474ae",
+        "dest-filename": "unicode-match-property-ecmascript-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57",
+        "sha1": "20813df3d712928b207378691a45066fae72dd57",
+        "dest-filename": "kind-of-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119",
+        "sha512": "7e9a1ed93d116c7c014c150e7ed01f04f683122d3ab9f6946a2d2613a627d6469c7374a74c4adf6ff87e5fde155f323ae2b2851d82265d2bddc061829b03aa08",
+        "dest-filename": "nanomatch-1.2.13.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b",
+        "sha1": "b01abbd723acaaa7b37b6af4492ebda03d9dd37b",
+        "dest-filename": "html-webpack-plugin-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz#a695777efdbc419cad6cbb0e58458251302cd52f",
+        "sha512": "b4e6cfa86998f57f0c50cf22dcc12299899b9cb2dfd39fd057980f96447c310dd48fc1bc076828bc4d54e1c41c058b6fdf299c93d63c7083aee306a88b290c65",
+        "dest-filename": "electron-to-chromium-1.3.103.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d",
+        "sha1": "d0d4685afd5415193c8c7505602d0d17cd64474d",
+        "dest-filename": "nopt-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2",
+        "sha1": "87774c0949e513f42e84575b3c45681fade2a0b2",
+        "dest-filename": "hpack.js-2.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c",
+        "sha1": "8a16a05d445657a3aea5eecc5b12a4fa5379772c",
+        "dest-filename": "utila-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1",
+        "sha512": "2f784a57947fa79a3cd51eced362069f0a439a4a7a13df365e1b5bbb049edcee2a3ad30c32da1d89c0120350a7cb653e6825dc3699a5fa6e1d3ecbec2778dab6",
+        "dest-filename": "arr-flatten-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858",
+        "sha1": "2b3a110539c5355f1cd8d314623e870b121ec858",
+        "dest-filename": "css-select-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8",
+        "sha512": "0d3565331dc860f7b4fc925c60fec6c60eedb5966edc822786e1216dc86eaa7798f7059ee4e8f2da65cb05a4055109a8d005b6af7a86ee6d6683cea3b3e82795",
+        "dest-filename": "ignore-walk-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38",
+        "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
+        "dest-filename": "to-regex-range-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.38.4.tgz#71a515d01f4f2bd48a67495804f659a46c35303c",
+        "sha512": "25bb8025006775c096e8125521bdad3e3339c22b888f3d8b5256f25713486b0336c05294055f64af437744d04917172b084b80f68a6b3140a8ca625dacc5157c",
+        "dest-filename": "app-builder-lib-20.38.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5",
+        "sha1": "8e890a183d8ee9a2393b3844c691a42bcf7bc9f5",
+        "dest-filename": "bonjour-3.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.2.tgz#12d310f255360c07ad8fde253f6c9e9de372d2aa",
+        "sha512": "16cca02317af8b58d288f63d87bbd99811546c039c6d89bd530ca22cd755b0b46cff959ef4e6f934c3db1985135a22eae4bf9ece555d13403c6db304e42593a6",
+        "dest-filename": "renderkid-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac",
+        "sha512": "2ce1f120e68f61d1e5251b4241f0c8559b5fc3fb9f33cfab563eb8f51207cdc9bfbc6c1045716de8e3ea2055ac9b65c432b34812d591eb8b18d4b10a0f6bc038",
+        "dest-filename": "deep-extend-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9",
+        "sha1": "9bcd52e14c097763e749b274c4346ed2e560b5a9",
+        "dest-filename": "depd-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0",
+        "sha512": "cd5a5af282994b3e5b4cc4c50a57357d03a7cb2133a65e68ce98b507961cbc1adda213231f6adfb01b725dcb8dbb08ec0c85e6058945d8de45949621476f6df1",
+        "dest-filename": "public-encrypt-4.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-7.0.0.tgz#da9a72df71dc77fb938162025a5fc658713c98ab",
+        "sha512": "e6d8398c139dd312178f08f83c39da7ce5cbe53c8f5738f12dbcb80cf29ebf9df0bab117a7b22ca2305a0f82e3e4ce70ee3c70d296e4114d1f1443e670aa0c9c",
+        "dest-filename": "fs-extra-p-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6",
+        "sha512": "a6125f41506e689339ada3a926349f9220fa0696c213836cfff2da5e5eb0198b54058f379d64ba45ff6d5e6d9ef1568aeb42448d895d6cf89ffc0d81d42da034",
+        "dest-filename": "invariant-2.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d",
+        "sha512": "578f2494a665f13e8ccdab5b2e5cf344d84c7a9132b3d638a06169ca9045167d602c8fd043d1ed2cbc9624d6cf97018b7a53953848a351b4d325e2cb239f632f",
+        "dest-filename": "sockjs-0.3.19.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3",
+        "sha1": "3e935d7ddd73631b97659956d55128e87b5084a3",
+        "dest-filename": "source-map-url-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336",
+        "sha1": "28a6aae7428dd2c3a92f3d95f21335dd204e0336",
+        "dest-filename": "object-keys-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.7.11.tgz#d7267a1ee9c4594fd3f7e37298818ec65687db63",
+        "sha512": "bee1a68198e3a77ce371ead083e240fad18e9dc3a724b59592df00cdee5e5902f04d018d8152dcc8e4ea8120b1593478278da28c76c1c67b9168bd51bfb5cc77",
+        "dest-filename": "@webassemblyjs-leb128-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.2.1.tgz#112dc8636121fa71fd524e1a8a5b4470ef7a2732",
+        "sha512": "c96e216595dd34df8f6a28f92550224efd6552c00de5044153936aa2d42ac187559147334a60f39bae952eed1ea23899b76cc5798a6d4c50c06256a50c6b8774",
+        "dest-filename": "read-config-file-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0",
+        "sha512": "b0f864cf401129b7f8ad142dda14e9007aa7e3b5f79652e45069fec442732e3c18f0b46cda9d2fee58ef239132a113bf99ec6b36e9cd1028ac66cfa0c36cf3d7",
+        "dest-filename": "browserify-cipher-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e",
+        "sha512": "f837e8fd2090aabc31e3ca6d2d518b744dfd62d591b8a73f63d239172d0fd430c107d96c007a63704250b7ee0889fb923924cb04a24e6c9a8cbda3b5a4813c2d",
+        "dest-filename": "@babel-plugin-proposal-async-generator-functions-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-zindex/-/postcss-zindex-2.2.0.tgz#d2109ddc055b91af67fc4cb3b025946639d2af22",
+        "sha1": "d2109ddc055b91af67fc4cb3b025946639d2af22",
+        "dest-filename": "postcss-zindex-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0",
+        "sha512": "a77d9c385e6ad19aacf6e06238d2982e6e810a50a80423393bd25f7944a59d02c14f161d4cafa95be9d77e59bc52429dd9462511b633e6a122d09b9947d7244b",
+        "dest-filename": "asn1.js-4.10.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a",
+        "sha512": "d15e65e028b3cefaade43e386935db159cfe16dc97575beb0cdeaaade971b5f610296d0a3b45b64ff86413cc6f19aff9e342e466591a5233b86a29584c5b4755",
+        "dest-filename": "follow-redirects-1.5.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6",
+        "sha512": "d652ca07632edda18fd50ff67823b1d1f35b44c7bb5ddc24b703abba17eaa9dd2b2095b03780e1f84de1acf4a50c25e7491ed4b59d4ddfcad55e6fbaf8c12125",
+        "dest-filename": "form-data-2.3.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812",
+        "sha512": "7962391c6f4da7e787575290862b175b033ee043cf61ee5d157d546591fb93f1372730c46b3547f951a5662e91f7866a226abe0370f598212dac521f83f13bb0",
+        "dest-filename": "hash.js-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11",
+        "sha512": "d46ea32550d6aedd2b2bdf64063bc4b7389934220202ebc83e44a2505210c553f4e91095a6addd983a36a22e8006961a0d869346bebb04484bf2bd708046592a",
+        "dest-filename": "regenerate-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f",
+        "sha512": "f638d415b4cf7c4cb747f69dff6a0d6cab56f47828be5e4ed45bc558a90a6e5357a0dfcea2eebef7e28aa213cad7761cdff4f2ba7c96849a7a82f44d47f3cf03",
+        "dest-filename": "normalize-package-data-2.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz#8cf54e9190706067f016af8f75cb3df829cc8c66",
+        "sha512": "47a1d4ddd7ad7beaf0b1d01facecd3944f4c729938463537697de08bd82bb66ba0418d2eefd5fb7a8814bdf5c0e6c23cd4c7ead5c9fa020c6285f377dd24e324",
+        "dest-filename": "@babel-helper-wrap-function-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f",
+        "sha1": "0df29351f0721163515dfb9e5543e5f6eed5162f",
+        "dest-filename": "html-entities-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c",
+        "sha512": "062a0ed717f7845c33e2473a881848de27831689a9321acc9670c50b8ff4fef779328929b8073747e2d86f04c0f40e5873da6af5460fa9f7caa56d8e6eec17e4",
+        "dest-filename": "browserify-des-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+        "sha512": "52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+        "dest-filename": "source-map-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec",
+        "sha512": "5d1b118dd7fe8f99a5fb2ffa18a1cf65bac5ffca766206b424fb5da93218d977b9a2124f0fdb1a0c924b3efa7df8d481a6b56f7af7576726e78f672ff0e11dd0",
+        "dest-filename": "punycode-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377",
+        "sha512": "a99af204e26357ffcb6b12d357a502fff59ec27781dcb71738bf4d3fefa8cca557b08208a66ff6735dd40e20fd269d9e4e1b1e730f66de33ea0f04f2a1b71d6e",
+        "dest-filename": "es-to-primitive-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6",
+        "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
+        "dest-filename": "static-extend-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79",
+        "sha1": "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79",
+        "dest-filename": "asynckit-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7",
+        "sha512": "224a69e6c715dcc498c58dfdca6878e592c479cb1376ffd78f609a41f23c44b32ec22ed7be35fd1ff7e1ada892b94f82e70e4d4c3bb8654ef6c4d8999eeac13e",
+        "dest-filename": "decamelize-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca",
+        "sha512": "6af0d8af4481dc3c0ef73b0ca2fd20282112158a829c4e21abfe33dd375496e904cb9b7d0b4611abb1cbaec379d8d01ca9729a7a97820f49fe0746ab9d51b71e",
+        "dest-filename": "is-descriptor-0.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+        "sha1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+        "dest-filename": "require-directory-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb",
+        "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
+        "dest-filename": "object-visit-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42",
+        "sha512": "4eb7e30a39388cb85c27218c6329811faa135dc5a361b5005d31c36ed9d61e3642db987471d6a31ee3c4d73c5be03566bbc72b7e1f87c07fd632ec8b1b49c706",
+        "dest-filename": "minizlib-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716",
+        "sha1": "747c914e049614a4c9cfbba629871ad1d2927716",
+        "dest-filename": "reduce-css-calc-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464",
+        "sha512": "2759c4506bfe3245d2d3078735654a249f94acb7de3f1456a4ddc2f5b122f5f2f12f6fa0816f780d0be06155ec693df43c6c1844864a3595eec8c869dc38b86d",
+        "dest-filename": "htmlparser2-3.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f",
+        "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
+        "dest-filename": "strip-ansi-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f",
+        "sha1": "f32eacac5a175bea25d7fab565ab3ed8741ef56f",
+        "dest-filename": "timed-out-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463",
+        "sha512": "a8e84f6bf163eece9363c1fc7ac1aee5036930c431cfbf61faeaf3acd60dea69fef419f194319fe5067e5de083b314a33eab12479e973993899a97aeae72cc7a",
+        "dest-filename": "class-utils-0.3.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.6.tgz#16e97aca1ec1062324a01c5a6a7d0df8dd189854",
+        "sha512": "7563fa2c99bd9ca4fa00b69af9b9cbdb8ec61c73168abdef4a5676f881e01e092d650c742f752fab6b8059cbb321ef9fba346c616056daaeb6d82e54bc62bd89",
+        "dest-filename": "@babel-parser-7.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c",
+        "sha1": "f8f78b76789888ef39f205cd637f68e702122b2c",
+        "dest-filename": "buffer-fill-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+        "sha1": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+        "dest-filename": "code-point-at-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06",
+        "sha1": "d410f065b05da23081fcd10f28854c29bda33b06",
+        "dest-filename": "parallel-transform-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c",
+        "sha1": "161c7dac177659fd9811f43771fa99381478628c",
+        "dest-filename": "statuses-1.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c",
+        "sha512": "db0df547b489b6278926742d19ced154bd92b4cdaf19855fa943af503c47e9b0ba6894f13f14c5d069c8802caeeed8e872489458061045bc5aeef2a7df8b39b1",
+        "dest-filename": "make-dir-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb",
+        "sha1": "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb",
+        "dest-filename": "json-stringify-safe-5.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790",
+        "sha512": "bcd2b12474c428d4e18dfadd2701dcedbaef33a7957afb8ee674e3e9ecfc650d6a6d74ef1ad86e71117b4b8bdfd9cafbd505674fbd15df8bf44b50f242cb62d3",
+        "dest-filename": "figgy-pudding-3.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+        "sha512": "9ff4a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
+        "dest-filename": "string_decoder-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4",
+        "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
+        "dest-filename": "arr-union-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8",
+        "sha1": "85982878e21b98e1c66425e03d0174788f569ee8",
+        "dest-filename": "builtin-status-codes-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838",
+        "sha1": "cb3f3e3c732dc0f01ee70b403f302e61d7709838",
+        "dest-filename": "balanced-match-0.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz#9f1dc76926d6ccf452310564fd834ace059663d4",
+        "sha512": "471ef2383642d4bfd3f172a8ff690dcd501069113cf0068cbc8d4417f5e78f7196db0ccde9fa29f430d6b8500a515147eefa33933dba0f33f4ab258b28b2153d",
+        "dest-filename": "unicode-match-property-value-ecmascript-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3",
+        "sha512": "af60db25e838b2f62fb771ce4bbe14e1e58ab1400c447d3567576cd73c7c28d4cfb694cbe4902c745bfc04dc8ea55a9d1611e49110c883907802cc6692302599",
+        "dest-filename": "@babel-helper-get-function-arity-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0",
+        "sha1": "201095a487e1ad36081b3432fa3cada4f8d071b0",
+        "dest-filename": "nugget-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz#d87ed01b8eaac7a92473f608c97c089de2ba1e5b",
+        "sha512": "1643e2c74d09f40fd7597bf856828904c79293263dc7f4ea221efac3371d7e5e7b44925c7fc09e850d3cbb07e108336d45062d1d02814f02990c4ca3135dcbc2",
+        "dest-filename": "@babel-plugin-transform-template-literals-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84",
+        "sha1": "98c23dab1175657b8c0573e8ceccd91b0ff18c84",
+        "dest-filename": "forwarded-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9",
+        "sha1": "26e61ed1422fb70dd42e6e36729ed51d855fe8d9",
+        "dest-filename": "buffer-xor-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524",
+        "sha1": "21e0abfaf6f2029cf2fafb133567a701d4135524",
+        "dest-filename": "browserify-rsa-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c",
+        "sha512": "2ca50ac2e24387135adee7ff2cf47f2958e6fe5deb06ab587823807a4bc6f05d6f22dc4c529b9e19df788bf6ac0c3afcff5bbb227c73140e447868e1846e6630",
+        "dest-filename": "html-minifier-3.5.21.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd",
+        "sha1": "d545635be1e33c542649c69173e5de6acfae34dd",
+        "dest-filename": "camelcase-4.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae",
+        "sha1": "9e6af6299d8d3bd2bd40430832bd113df906c5ae",
+        "dest-filename": "glob-parent-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd",
+        "sha1": "c98aef488bcceda2ffb5e2de646d6a754429f5cd",
+        "dest-filename": "loader-utils-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz#bce30b2cc591ffc634322b5fb3464b6d934f4433",
+        "sha1": "bce30b2cc591ffc634322b5fb3464b6d934f4433",
+        "dest-filename": "postcss-discard-unused-2.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6",
+        "sha512": "8a405c5b0caa5d04872ad72209c72dbbd61f3db158678fa06c712613443c8f37136108397470abde0db0c006633e825f4155d9aba297023a573937f9fdc8d3ef",
+        "dest-filename": "mime-2.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87",
+        "sha1": "fa7168944ab9a519d337cb0bec7284dc3e723d87",
+        "dest-filename": "http-deceiver-1.2.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2",
+        "sha512": "3733558490d8a7071e5558a2f3f1eee8329f0f61be36b407952fd5fea82fefadc462e755c0470c40dc5dda587ed15ad40725cdfe826497982b3a1616bd05188b",
+        "dest-filename": "split-string-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/internal-ip/-/internal-ip-3.0.1.tgz#df5c99876e1d2eb2ea2d74f520e3f669a00ece27",
+        "sha512": "3575e01120b69cd56d53ea6a982f5ee91f01d46a4ac73b004217dfbe1e402fbf6a2a7a1d77e2fbb671109938940159e0a8b6a53db4aa440ed718810be6709dd1",
+        "dest-filename": "internal-ip-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+        "dest-filename": "read-pkg-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9",
+        "sha512": "6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+        "dest-filename": "fs-extra-7.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/coa/-/coa-2.0.1.tgz#f3f8b0b15073e35d70263fb1042cb2c023db38af",
+        "sha512": "e707d34cef04dbf8dae23152c5e3d7946e6746ee5b06d2ffaf51c2229256fe5cd3eb20ed2a5d2ed19e28fd5a73df62292a6067ec77ab85e11942003d3760daad",
+        "dest-filename": "coa-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.0.0.tgz#d52cf4bcdcfa1c45c2dbefb4ffdf6b00ef608098",
+        "sha512": "6c0ff11a2c16335eea8e5948b3d5ffcb4123b01eded00574f05dce2fc50fb2836435189b22ebbc7f578a4e743c40ed43b5e28a4f14d4027f88116513a08c0638",
+        "dest-filename": "icss-utils-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c",
+        "sha512": "564fbbf2136345bb22bb8f7300f00bc536fe254402cf56a896977ca2c385d7a0469cbb6c783db59db1e02cf194c2b5c4bab6608823949afb371314eee05e71eb",
+        "dest-filename": "@babel-helper-simple-access-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f",
+        "sha512": "87205597a8aaa94389f05a917be97f812f07fa42988eb12775de4f9b531f06db04280d37f0792475b025ffbd840171b2a270ff3c5b2f9951be12f708a6588c06",
+        "dest-filename": "original-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz#8c74ca474d4f951d01dbae9bd70814ee22a82005",
+        "sha512": "15477dee0b8d1ac0994207933ca760c498415e451b31363a8453dfd98e0e79d5dde3c1fdec9fac398d8bb5aaba586569207f28fd318e54d895cff49ba443091a",
+        "dest-filename": "@webassemblyjs-wasm-edit-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef",
+        "sha512": "b25baf659d588932c3e63b2a65c0e61725761304e8c976417e9a153a692d3265be5449e181a9051e76ac56987ae5f3a318f4d6374370dfe5d069278c6b2af492",
+        "dest-filename": "querystringify-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00",
+        "sha512": "8ba7477b71322e33260e5535fdb190a44c36e574a390950b3ee0152826cd45e7d056ae3cc97294a70839dfc17b0194dff64cabe7bce3fbea50165b546b91fbc8",
+        "dest-filename": "watchpack-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e",
+        "sha1": "0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e",
+        "dest-filename": "sumchecker-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693",
+        "sha1": "c98d9bcef75674188e110969151199e39b1fa693",
+        "dest-filename": "defined-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7",
+        "sha1": "308beeaffdf28119051efa1d932213c91b8f92e7",
+        "dest-filename": "camelcase-keys-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.4.0.tgz#c1eb4c89a209263f8717c782591523913ede2561",
+        "sha512": "5f9d4bb5ed6009851d970845dbcfb660c3b453a59e37418ba60a40ecb2bb99b7439e44188b0bc4a66a5ed05fdcbf92f5e046f182b75ac801b72444c1bf475b5c",
+        "dest-filename": "regjsgen-0.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a",
+        "sha512": "63d27a6635eda1887c4675d508c394fedb439a4d5a063ba7abdbced2d6b9c7ce560d08907d417db083c121375b8a2215701a34dc78b78ccc62801b6c75d95747",
+        "dest-filename": "aproba-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850",
+        "sha512": "f0c87d87ac558a28e3dfa83b0f18be6384ba84d195f7abdc259aff4ab9478752d1fe9127ffc8fffaa2016ece3860a97af4badf72da78403f807562d332a11901",
+        "dest-filename": "json5-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff",
+        "sha512": "3091bd962899fa881ce13cd4c2ebdb111d4945d82f505481e7e551fe0e61f367c668845631675db4a0478bbfec5617e3419e927a197286f418adc6246942292e",
+        "dest-filename": "create-hmac-1.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230",
+        "sha512": "566a748c8a76967df95135eeaf2be3ce48c6751c9ff5bda54d7b9261488f9b345c977143b58a80c0e9d3264027803f525a19e82730db4cac1a3ab67e493b7135",
+        "dest-filename": "unique-filename-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d",
+        "sha512": "8f02b6515e1c9cfa5b706efe55101129364f516a30c1703c6f31f934feae774a1e031c983ee1995000bb84cba0a42773e01792665d8397d93ae821c9ff8e9961",
+        "dest-filename": "define-property-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.1.tgz#026f12fe7c3115992896ac02ba022ba92971b979",
+        "sha512": "072e99158ec44d639cf5115a0086f6dc88c955c33876f242fcde7b9e6773f514a4317bc05c623b4b2565030deff2f8ed0d196a4e18150d59939ebf5fa8c97193",
+        "dest-filename": "loader-runner-2.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80",
+        "sha512": "f1c2412f9b53776392d1d3388f3d3bc107798347420aa2215313c81ad65f6b92fa85696f5793074c84f2fc3040b05f8e7b62d2d57de4ac1521370686516a56c7",
+        "dest-filename": "isbinaryfile-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e",
+        "sha512": "39b37a875bf67d32529945e84b79cc43dd8b6c32bd6dee1357ee86fa899094624575c517e6178a8b52d9d589d13088304cb123dc4db86d3ead6278b9d2b9427d",
+        "dest-filename": "chalk-2.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172",
+        "sha512": "d46e944c38bb25cd442c5c27479f075787caf4e40ae12e8df7ce5fd7aeb1a97c698d4ea99711484896b605af4a090b856bc4429e3fe548525b1e8ed414306750",
+        "dest-filename": "eslint-scope-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc",
+        "sha512": "05ae66f7f15ae17b7d79bd842d7b7bec9c550d5f30eea42b1f4cd2fd359225d2f20304235a83b3a738f997055fb43cfa9ff10ebb7b4d0024bce2fe74f6ac2724",
+        "dest-filename": "widest-line-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258",
+        "sha512": "9507b8f183ec30902283eca7819f3b2eeb3e345fb79adbbb0d5381bba6ff8073b56292b0223e405a367f4ce4bb8b8e870ff522c7359bd737960d97c667789872",
+        "dest-filename": "pako-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.0.tgz#7050d1412cbfc5274aba609ed5e50359ca1a5fdf",
+        "sha512": "b509074bc555c566eb8e73435e0b7bffe4ae3c9eea0ef0f46367ba6cbb68425b91d923ef9663d471f714ef92f52806a586a50b948149949e810df9d8c89c49b3",
+        "dest-filename": "browserslist-4.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14",
+        "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
+        "dest-filename": "pascalcase-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+        "sha1": "9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+        "dest-filename": "events-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748",
+        "sha1": "b22c7af7d9d6881bc8b6e653335eebcb0a188748",
+        "dest-filename": "resolve-from-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz#690353e81f9267dad4fd8cfd77eafa86aba53ea1",
+        "sha512": "d93843866e25238a15edf550ea934d2beb31f9cfc6339fd268c2f4c3faf8641eec027783fe988326dc1d2a535c9177b218aef0970836136c37dc2fc787e5450a",
+        "dest-filename": "@babel-plugin-transform-literals-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+        "sha512": "35c7402f0a579139b966fbdb93ba303944af56f04a0e028fe7f7b07d71339e64057ece194666a739e2814e34558e46b7405a0de9727ef45dd44aa7c7a93694e7",
+        "dest-filename": "is-buffer-1.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b",
+        "sha512": "dae52a6b3b8a95369223f742f00ce2714724efe22b11a3a737f7b48dddd7b6dd4a706a70c77d2fe7498bee83f2aff87d6cbdc4e1a65c715c29c0ffb95bd56392",
+        "dest-filename": "npmlog-4.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/builder-util/-/builder-util-9.6.1.tgz#4625620b1535fe40dcacb178d24fe56d0d7c8957",
+        "sha512": "f0c9632938de57e03e2cb55ec6e58457712959b89472c1c7ac1e01836a8da3fddd0bebd3a3a83fdbbf96dc88fb223d544e86d290d06cb4589e5a28d7242728f4",
+        "dest-filename": "builder-util-9.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791",
+        "sha512": "a58008cde468f09e8a3c4689d1558e8793f391bc3f45eb6ecde84633b411457e617b87cf1f1dab74a301db9e9e8490a45fe5d1426d7a7992ea2cd4bc45265767",
+        "dest-filename": "debug-4.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe",
+        "sha512": "68a4b85908cf7a7471890b02f7730d7e3c7e9db1783c0758ce677fd49223f07633a9f6eef3a6de4ee3605c3ccf9275a4d27d2e0119727b0668e2cfbe112dfa3b",
+        "dest-filename": "json5-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-6.5.5.tgz#cf97cdade71c6399a92c6d6c4177381291b781a1",
+        "sha512": "eeaee0b51403252cae1078ee5601e851ad95b9e98588232b7d073d4dcd3c5d301ce198ffe54d5bb902741d4ea2edf2a35d4d3d4958129b16b8b0bbeebd2f08ca",
+        "dest-filename": "ajv-6.5.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594",
+        "sha1": "d2646f5e57f6c3bab11cf6cb05d3c0acf7412594",
+        "dest-filename": "domhandler-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.4.tgz#95dac09892f4f183fad5ac823f08f42c0256551e",
+        "sha512": "8cbe9e148ce8377c5412f6e8df73809120c4d9520a538250d7010d3a8c2cd43a5f9eb75aa51fcadd0d7f7c1e3732aef04257128119b6de716bbe88a8b9f33b78",
+        "dest-filename": "posthtml-render-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022",
+        "sha512": "8dff38bb1cf08ae88854a88e2e97d893b378e934b2f2e6d3a279a7798f6fae91cd027a74401b76071595f5d3b7fe3f81a1501bf9ae46e980cf5b73391ce74c59",
+        "dest-filename": "mimic-fn-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz#d952c4930f312a4dbfff18f0b2914e60c35530b3",
+        "sha512": "abecaec56e03b138cd71e5224f32b42fe01f434cc3f6b59a4cb894a8703ca74831c7b96ed44ca57a77f38de2163643f2e9eff4546fd68f0f6e7fd2ee790c0b3b",
+        "dest-filename": "@babel-plugin-transform-duplicate-keys-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080",
+        "sha512": "b0dbce0b311036bfeaaef260737506fe40f842d947c9caf3c12fba99f4ebad2abdec1bda61c3d9648d594aa1923d1ef70b19f82ca4c3e0fb6d4707d4ee35aae6",
+        "dest-filename": "har-validator-5.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz#9c9ac41ecf9fbcfffc96f6d2675e2de33811e68a",
+        "sha512": "f19458e6265b65db4d144e5416e9c1f269811006d223782ec1baec0a5e1f59d7d188072fa90a5ea9de4a1e14962cbe70bb1a39df371a1990c153ae2a827e08e1",
+        "dest-filename": "@webassemblyjs-helper-wasm-section-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf",
+        "sha1": "8a18acfca9a8f4177e09abfc6038939b05d1eedf",
+        "dest-filename": "isarray-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544",
+        "sha1": "8fded7324ec6e88a0ff8b905e7c098cdc086d544",
+        "dest-filename": "unquote-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618",
+        "sha512": "31fad10435b321689f82aead263eb4824030b4b35beac40f95c16b48e7e570fd5a1669abb8a436c119f37bff15ea4832cfb1f7145f0da73bfbf2667b5cb2df96",
+        "dest-filename": "errno-0.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+        "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+        "dest-filename": "has-values-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e",
+        "sha512": "fa137f661d83d3c331eb9a59ff88396ec98d89952e0a10e241f4d443ba89af8fe4ba8a42afcf3166c017bfa981a1912c508e0eb861e55f9f6a13de0ada6316f1",
+        "dest-filename": "big.js-3.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17",
+        "sha512": "e19c48e9dcb896b63a147cdf8b2d5a10e5e0bb82c8b16d8c8701b454129d7281a81ff5cb16068749d2d31abe0ef017ba03caf730ea6112223c19cd67d1e71fde",
+        "dest-filename": "clean-css-4.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977",
+        "sha512": "d9740009f1252a2f529556f509869d2835efa1a8cf80154f9ff80e40bad3bc774495a561afb6446ea25a46724b54d79a23870c10081509e04c285e8c5910c244",
+        "dest-filename": "spdx-exceptions-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc",
+        "sha1": "9326b1488c22d1a6088650a86901b2d9a90a2cbc",
+        "dest-filename": "findup-sync-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+        "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+        "dest-filename": "map-cache-0.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513",
+        "sha1": "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513",
+        "dest-filename": "jsbn-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296",
+        "sha1": "426bb9da84090c1838d812c8150af20a8331e296",
+        "dest-filename": "array-flatten-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0",
+        "sha512": "d31cb803fb707eb4429e485f93c12b0e2e43a9d02c02a786c61b78c64094aecbe185b40db3b13ee2357408defe34a218d1a1c4ef6f97beab41217cc3df565b5d",
+        "dest-filename": "ejs-2.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1",
+        "sha1": "9aecd925114772f3d95b65a60abb8f7c18fbace1",
+        "dest-filename": "http-signature-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4",
+        "sha512": "0ba901fd624389ac4e34b2509c5f1c731f5211ea134cb7a4f1155b68e22cac0512f15ac11177e67929c2671ca073e5c2dac34c048c0e3a77dcc62ca78c7b1549",
+        "dest-filename": "yargs-parser-11.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e",
+        "sha1": "eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e",
+        "dest-filename": "ipaddr.js-1.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron/-/electron-4.0.1.tgz#c41eaee9e081c2e5e4a4a4a761b7577a77d2eb18",
+        "sha512": "9015832e7d55abc4e6ebefc7a5073c8248d7ef0272408f2ffe57f69008ab7e2d10e1c5e1eaf063a3316f57553ff601826f22a720333e9bcff0a722488e0e30ee",
+        "dest-filename": "electron-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20",
+        "sha512": "785bbb5e282fc5d6751137db80f068860c90fd9fbe0b4784853a2bd2a470070f6e9f0f8bd3fe95f30912b86833753864892e654a9769b4e40f0fc024e346beec",
+        "dest-filename": "convert-source-map-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613",
+        "sha1": "5887966bb582a4503a41eb524f7d35011815a613",
+        "dest-filename": "trim-newlines-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.1.tgz#b1a7a29c4abfd639585efaecce80d666b1e34125",
+        "sha512": "bcce7c0f07672a6b72f8548fcd3d782bd2576fdd07fa3e5e99a4782986ebd8a4c8cf4d161c66d639ee608504f1db7dd908b66dac60c02f32b072312d4addf998",
+        "dest-filename": "duplexify-3.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.1.0.tgz#dd7fca995d48ceee7580b4851ca057566c94601e",
+        "sha512": "b359a5276f26bfee7a21e6e1e9cf5a5e355ed753b76747034f0006781d0f09c5331c0dfb7c3c46812f191a860d3193feac11e3db577fa1dd70b98a1f4d52da42",
+        "dest-filename": "builder-util-runtime-8.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d",
+        "sha512": "d75e5f2e1bd956a5b01cf6c29729edc4455f5437e5f432cb4ee26fab78363bf3b18bc022368b801ef0d2cc74b4be250973e579be6ddeabdd57c2a9fd769e2344",
+        "dest-filename": "miller-rabin-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27",
+        "sha1": "854373c7f5c2315914fc9bfc6bd8238fdda1ec27",
+        "dest-filename": "os-browserify-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848",
+        "sha512": "1a2d56e24d39f60c916f2554650e2612a2e6d1821488661fbf1845e92225937ba2d5657131319f19d4364889e1dcf0eb45356f3ca8142e4a49b53e111f5d3e54",
+        "dest-filename": "minipass-2.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029",
+        "sha1": "2e68442d9f64ec720b8cc89e6443ac6caa950029",
+        "dest-filename": "toposort-1.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b",
+        "sha1": "6efecc2a4dad8e6962c4901b337ce7ba87b5d28b",
+        "dest-filename": "xtend-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2",
+        "sha1": "b17aed82e8ab59e52dd9c19b1756e0fc187204c2",
+        "dest-filename": "domelementtype-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449",
+        "sha1": "e8bd0efee58fcff6f8f94510a0a554bbfa235449",
+        "dest-filename": "cross-spawn-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b",
+        "sha1": "405923909592d56f78a5818434b0b78489ca5f2b",
+        "dest-filename": "truncate-utf8-bytes-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac",
+        "sha512": "ae64d9f64cfe7f7ac2bcad930f551efe86659ecece1a82163f87dcde5971c515e53a41caa163cf58939f158a484da6d2a30e374096d12281d05edb75d1595dc9",
+        "dest-filename": "no-case-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c",
+        "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
+        "dest-filename": "object-copy-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6",
+        "sha512": "83031d8602471ae8fffb01c926cf5ee8f702b33a714756f6dfa8a0ace914a1f1a1a89b86f9a9a520ac00a47d485b559697ba2f671b17e3d94c0562f149d9b90f",
+        "dest-filename": "update-notifier-2.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43",
+        "sha1": "05698e3d45c88e8d7e9d92cb0584e77f096f3e43",
+        "dest-filename": "import-lazy-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz#f17c49d91eedbcdf5dd50597d16f5f2f770132d4",
+        "sha512": "bc34e07f5f59115ea6c77e7288f25ee1f4b4da63d05147013705904991574b34d26ec24542f1edec3ab24b72caf2839600b14eb09fbc6dba818248ab66d783e5",
+        "dest-filename": "@babel-plugin-transform-block-scoping-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637",
+        "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
+        "dest-filename": "repeat-string-1.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979",
+        "sha512": "9bf7ba8e05aef3fbf99e20942908bda9097c41d78476e140f7ac470c3cc51aa972d0e3a323b73eeb428cff6b29a5f9d453d2496a07fececfb21a1a923858fbd6",
+        "dest-filename": "npm-bundled-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c",
+        "sha1": "e303a882b342cc3ee8ca513a79999734dab3ae2c",
+        "dest-filename": "cookie-signature-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c",
+        "sha1": "b534e7c734c4f81ec5fbe8aca2ad24354b962c6c",
+        "dest-filename": "caniuse-api-1.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.2.2.tgz#44e10fc24e33af524488b716cdaee5360ea8ed1e",
+        "sha512": "7ca0ae0fa50550c911e78d5e0d62feda287fc456415cf3a0ffb11015e4e5b8c0de6dfa91e23ae96828cb8645a5412e214fa9d16b63cc1205ca6d1079fc7d9fa6",
+        "dest-filename": "@babel-types-7.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91",
+        "sha1": "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91",
+        "dest-filename": "forever-agent-0.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f",
+        "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
+        "dest-filename": "has-value-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1",
+        "sha512": "13ae1814f52cb051c4141be96db8ebe383422ed23502887143c6528898d02ec90074abab89810fe95c8612c4431fc49ca331a991a5f5046be16a7a82c2470467",
+        "dest-filename": "send-0.16.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7",
+        "sha1": "928f5d0f470d49342651ea6794b0857c100693f7",
+        "dest-filename": "on-headers-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6",
+        "sha1": "b91d806f5d27188e4ab3e7d107d881a1cc4642b6",
+        "dest-filename": "dns-txt-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875",
+        "sha512": "92a6a0fcd97e7f71b0c8adb97e150c623f350543ab67d22e26c8c870313989c34cf452470159b755c503c5d2cfa10b53b94ca55a6e992249d8270c1a3f1b14ce",
+        "dest-filename": "diffie-hellman-5.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+        "sha512": "423563c1d5c8b78d3c308880a825f8a142ac814d84a801b3b363e9926e1a4186e39be644584716e127c5353af8b8c35999ad1ecb87f99602eb901d1a5f440ca3",
+        "dest-filename": "supports-color-5.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581",
+        "sha1": "96e3b70d5779f6ad49cd032673d1c312767ba581",
+        "dest-filename": "esprima-2.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051",
+        "sha512": "b3990b39c9c7d17a833be16fb9a2d7f030e3675f0218593b572807e3442828f510856e1edabbccd2bc14ab4b7c2100cec1849e2cad3553dd0e8f305399ed90a8",
+        "dest-filename": "kind-of-6.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1",
+        "sha512": "84ca74a270ca21a8c77c891d464dcfe02742984ae4600c710ed3f75b1ff89d9dda1a56aed952a1de666972e1641f6ed64242ffdd60423ce92dcc0f593809cc41",
+        "dest-filename": "p-try-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz#c95839eb63757a31880aaec7b6512d4191ac640b",
+        "sha512": "326ab1fdc4baf0ad6d4abbd12ed695fcba773595b35ed387516d88bc3be5dac8a1030261e00084d1e2fa03c16f3320c6f5a6deb37b1a07a74c8a62ceb3e1cca1",
+        "dest-filename": "@webassemblyjs-ieee754-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc",
+        "sha1": "d4f4562b0ce3696e41ac52d0e002e57a635dc6dc",
+        "dest-filename": "prepend-http-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae",
+        "sha512": "62f0b5495d5774e51a2fa831e42a06ae84f71aee3da4af7e4d9dfc12b3e574e596e23e3d188d472acf4357e286abfc3acbe2d9ef65b573c70acf6bf363eaa9ce",
+        "dest-filename": "timers-browserify-2.0.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53",
+        "sha512": "03de571280a96f74cef8a6732784bfe6e5b97cd7b6e838c11aa7f5a3db9cc8bc829a2d5d5eafc1ddcf226964df064dd5bdeb54c65d7a7bcb48adde6d78e09f1b",
+        "dest-filename": "@babel-helper-function-name-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290",
+        "sha1": "f6534d15148269b20352e7bee26f501f9a191290",
+        "dest-filename": "decamelize-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+        "sha512": "19dd94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
+        "dest-filename": "safe-buffer-5.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
+        "sha512": "00a71d4e71525804dde7f1823d1c6bd82870209f3909ecab1328d11e52b1439e9de1724c1b29b4b8088a9f4c5b2ce18e977fb24693938b8f38755084739014cd",
+        "dest-filename": "cache-base-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729",
+        "sha512": "68d75b9e3f4ff0f8dd5d4e326da58b2b6205de373f1280d86c2ec06b35bab68dd346c7d7c6c702f545ce07988388442b93221b5a9d922d075ae3e4006bb9dcdf",
+        "dest-filename": "braces-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57",
+        "sha512": "b54317af1944c525ba5361178a228648155d620b55f2a9472fe0b5d13b16e0f51163f89cf9e6b2b274a4c01e2403f981942cb2fc828327e2dcdf06d679a5edb9",
+        "dest-filename": "dot-prop-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-3.0.0.tgz#00d4863a6400ad75df93361a1608605e5dcdcf31",
+        "sha512": "86c2d5144e528c0e930a2b167895c52a788618ea4180c2e67ab7ced9a0b2094e6cee727fae901ea6a98589fbff1826d26ee7847802499e6490dab282fe0f0573",
+        "dest-filename": "spdy-transport-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4",
+        "sha512": "c7ed76c3f4e8fb81857e0261044a620dc2e8cd12467a063e122effcf4b522e4326c4664dc9b54c49f5a3f5a267f19e4573b74150d24e39580fbf61fb230ba549",
+        "dest-filename": "p-locate-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d",
+        "sha512": "7972b55089ead9b3e68f25fa7b754723330ba1b73827de22e005a7f87a6adce5392a4ad10bde8e01c4773d127fa46bba9bc4d19c11cff5d917415b13fc239520",
+        "dest-filename": "is-windows-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4",
+        "sha512": "96bd8464272d0b604d47b8fb5b32761690f39f1932d6c8dfc6fbd8132cf13726fa9595c7383984a09785bb826ea589647e16b5299a49ca8aa227ba60035aaaf1",
+        "dest-filename": "spdx-correct-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7",
+        "sha1": "535d045ce6b6363fa40117084629995e9df324c7",
+        "dest-filename": "supports-color-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/html-loader/-/html-loader-1.0.0-alpha.0.tgz#3f4ae7b490a587619be6d1eaa8ce16683580c642",
+        "sha512": "29cb9a2115935349058ce242b37d9adc9b063425a478e6a4d3f17fbaf24da77c7f37831c5dda87a5c2bae1c613a332bb40b3ca2ad52a6fd87bc11f4af6b61192",
+        "dest-filename": "html-loader-1.0.0-alpha.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz#46adc4c5e758645ae7a45deb92bab0918c23bb88",
+        "sha512": "1a0bf9b2575751e48ab2eccb91d76dca1c877b661a9edb3158a362ec0fbb2de0f5d84c510d64d1936f49097a5a1cf01b31a20f6528a5ee7fa5abbf16636558ef",
+        "dest-filename": "@babel-helper-hoist-variables-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5",
+        "sha1": "9f5772413952135c6fefbf40afe6a4faa88b4bb5",
+        "dest-filename": "svgo-0.7.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb",
+        "sha1": "0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb",
+        "dest-filename": "websocket-driver-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94",
+        "sha512": "abaadb743775a369809d0ade3bb6000c8c5ffd6871e001c18917fa77efdc553f21e38b2cfa51e0c5fd457a672a0e742df57ddcb7831c1ebf893069584ac2bb0a",
+        "dest-filename": "fs-extra-4.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771",
+        "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
+        "dest-filename": "has-values-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660",
+        "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+        "dest-filename": "json-schema-traverse-0.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2",
+        "sha512": "99b2a431d40ab235f80402f86d16138f6d5e74e7fc70ded71dd6142447be667f7d85511870cbca3dcb7522a35eefe0193e2ae7f01083390047419927aa62a565",
+        "dest-filename": "snapdragon-util-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/terser/-/terser-3.10.12.tgz#06d40765e40b33fd97977c0896c75b2b5d42142d",
+        "sha512": "dce0cf0b5795b76e4454d6f4e2cfcf907c4e9b328141417a6f0c2e47a8760db105f3f8f6eb9635524c0db4e93d6a6fe94717c9e473daa4e95494ee9cd7a98a41",
+        "dest-filename": "terser-3.10.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73",
+        "sha1": "9ec61f79049875707d69414596fd907a4d711e73",
+        "dest-filename": "querystring-es3-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901",
+        "sha512": "d0f9bd853437b1ee659755e285189cdc50c892eef40be88751d4ff5bddbaad28075794205ec61b29937c3120b7b49b52921b913b3bec42301a1443515ebfb5f4",
+        "dest-filename": "util-0.10.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a",
+        "sha512": "b60a7e765e5c1a4dbcbad624b41b2b16a03b1ca82b8603ec83a67f11f856238825d47c2af01fc6998ff4a1767a9c5f210d57ac4bf1699d8683fe439685842fca",
+        "dest-filename": "ms-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1",
+        "sha512": "a7fb5d26b3b8537f3b47da0c8dbd688fba9231a31f98ec9de23f61385a3165ed9b690b338077125a3bb26bf0a24f9920659291b9d1cd380d296173a5f2b4399f",
+        "dest-filename": "serve-static-1.13.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298",
+        "sha1": "6d1bb601b07a4efced97094132093027c95bc298",
+        "dest-filename": "buffer-4.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae",
+        "sha512": "be5302d9ff08daefdb646aa475f2d05bfd776628697a3ffb3e64a2310b1b61d771b93b09a7cbd17b6c7616f544c5983b15a39db38dd1380b852703d1e0c4d92f",
+        "dest-filename": "stream-each-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85",
+        "sha1": "ddd52c587033f49e94b71fc55569f252e8ff5f85",
+        "dest-filename": "csso-2.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.4.tgz#51cc46e8e6d9530771c857e24ccc720ecdbcc031",
+        "sha512": "10fb2dcd9db7ce71d454b2a3fa57173b52af664ae5c3e662addc2f3a69c09c0ff53c1e208325c9efb2d1902aa47dff92850f9caa8c42c4b40e87870a2133b988",
+        "dest-filename": "lru-cache-4.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc",
+        "sha512": "f934a47c83470e8e09f99a1b40b5a2328b90601f9455816db5103de05a44cf327b65da9c2f8b94510ed691d908e034a8cc69a005413f6b8ecbfb7f0f7a75e153",
+        "dest-filename": "stream-http-2.8.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e",
+        "sha1": "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e",
+        "dest-filename": "punycode-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16",
+        "sha1": "8758c846f5b407adab0f236e0986f14b051caa16",
+        "dest-filename": "object.getownpropertydescriptors-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz#7545da9ae5f4f9ae6a0ac961eb46f5e7c845cc26",
+        "sha512": "1864adfa06d3d2829c30398fc7849149f24f1355da3779104561b8821c4a430f5c9f91bdc7a682292b2061dbf23349daf4d2780ebbf4446ea36c107267908c8f",
+        "dest-filename": "terser-webpack-plugin-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6",
+        "sha1": "50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6",
+        "dest-filename": "is-absolute-url-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455",
+        "sha512": "7dec6150514f4c657cc9b02d48819b57a80e912bfc52d45b0c19c0c8b430e103ca920365b07d81c8f1ad314a9d5a4a2ce98091980a958b0819ac973f9910f365",
+        "dest-filename": "oauth-sign-0.9.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497",
+        "sha512": "bec19d9304820e95a63fcd277004d7ee279ae435907a6835520096e49f2daa3537958c3814162e8fcf49d024d5a2603b0447ef49977ce06987928f8cc45414d8",
+        "dest-filename": "ci-info-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+        "dest-filename": "wrap-ansi-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "sha1": "d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "dest-filename": "fast-json-stable-stringify-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
+        "sha1": "8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
+        "dest-filename": "from2-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc",
+        "sha1": "2299f02c6ded30d4a5961b0b9f74524a18f634fc",
+        "dest-filename": "vary-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde",
+        "sha1": "cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde",
+        "dest-filename": "redent-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c",
+        "sha1": "2cc0d66b31ea23036458436e3620d85954c66c3c",
+        "dest-filename": "normalize-url-1.9.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz#bbd8593c5c1fd2e3d1c322bb925dcae8dae4d62d",
+        "sha1": "bbd8593c5c1fd2e3d1c322bb925dcae8dae4d62d",
+        "dest-filename": "postcss-convert-values-2.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43",
+        "sha1": "7d229b1fcc637e466ca081180836a7aabff83f43",
+        "dest-filename": "to-arraybuffer-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02",
+        "sha512": "fdfd86a384e88271ff2af08848fece52c1e7f39853f67524c7103d0445b1167f8e8fda3c64d2e6ff8d217658122f2b8e8a6b2b4ca2d4304a2b41ec69fda3d078",
+        "dest-filename": "evp_bytestokey-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485",
+        "sha1": "bddc3de099b9a2efacc51c623f28f416ecc57485",
+        "dest-filename": "domutils-1.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0",
+        "sha512": "e0b9f5efebd54f493c696abeb7f6c5e5aadc4b71294fd818b56eba10f69c763fe60057afce7b27ca81cb3f2d8103c81b2107881e83ecbf099f05fb5f706fff05",
+        "dest-filename": "eventsource-1.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc",
+        "sha1": "4c2bbc8a758998feebf5ed68580f76d46768b4bc",
+        "dest-filename": "homedir-polyfill-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@posthtml/esm/-/esm-1.0.0.tgz#09bcb28a02438dcee22ad1970ca1d85a000ae0cf",
+        "sha512": "744546f884e7bea2866b8bf4e34b4ffa7f0b38a3aaafde2a8cbbdaedb139a677e6d8a1c9c2c2b3ebd27828cc6058bce76e9049cf2f2f41f09ac84937bcb66765",
+        "dest-filename": "@posthtml-esm-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz#cf7c25a1eee25bf121f4a587bb9e004e3f80e528",
+        "sha512": "eb5955d034b130067c032646eff0386b750f96b6ce068f0d210e2d2732cf01d18e43eca8342ee5e628c4a30dbb94100bda1ba67abd3528b4ba6c620c610c4aa0",
+        "dest-filename": "terser-webpack-plugin-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9",
+        "sha1": "e0e6fe6a28cf51138855e086d1691e771de2a8b9",
+        "dest-filename": "has-unicode-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded",
+        "sha1": "06ea6f83679a7749e386cfe1fe812ae5db223ded",
+        "dest-filename": "icss-replace-symbols-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99",
+        "sha1": "5a200bf92e0e37751752fe45b0ab330fd4b6be99",
+        "dest-filename": "reduce-function-call-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000910.tgz#58cca84780223291c28e92d97a9b1512260a9a8e",
+        "sha512": "7b2b2fe5e02c5c20677e785366c281b4264a760785691a8e95337be2409fcdd1ddcf4227dc4e40a29ecfcaa3c8ef9ec3b1d8d5c09396ac51c8ad33d8ce6965ea",
+        "dest-filename": "caniuse-db-1.0.30000910.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d",
+        "sha512": "2c3518e95d57b39785b2451562d2306ada23b7afbdc42f42867964fe360e3af9f714015f49a59d7716a10c6c8d1e1d1bd9d3176ba616da6d2d93c4dd55a5c794",
+        "dest-filename": "find-cache-dir-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003",
+        "sha1": "cb2e1203067e0c8de1f614094b9fe45704ea6003",
+        "dest-filename": "trim-right-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e",
+        "sha512": "8f5d94bb26f814caddfea4009bab821c090fb4ef050d34496410dde43d8a38bd9e2dacf5c9435d501fcd388caad22538ab87056abb140ab9c50cf05c9e4b2e3a",
+        "dest-filename": "express-4.16.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3",
+        "sha512": "356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
+        "dest-filename": "async-exit-hook-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd",
+        "sha512": "71a959302d74bb414c52aa22ba7236022188214b5422f89f37090784dba9647e1c6cd9d6d48b64a21fcd7f91c56260ebc163e3ad4c699194f42a1b82ab48e61b",
+        "dest-filename": "flush-write-stream-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14",
+        "sha1": "8e943d1358dc37555054ecbe2edb05aa174ede14",
+        "dest-filename": "get-stream-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40",
+        "sha1": "411cadb574c5a140d3a4b1910d40d80cc9f40b40",
+        "dest-filename": "path-key-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48",
+        "sha512": "c436d58327c34d3da98aea7f87c74aff2e1065f25149aef76f0d5667c6f85ccd68edfb05b9b515198704fb500db4ecc92442c6a58a06dbdeb5cf467a38095df4",
+        "dest-filename": "chrome-trace-event-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247",
+        "sha1": "df94fd8cf6531ecf75e6bef9a0858fbc72be2247",
+        "dest-filename": "param-case-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b",
+        "sha1": "fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b",
+        "dest-filename": "detect-libc-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9",
+        "sha1": "a840b4b8af6403264c8db57f4f1a74333ef81fe9",
+        "dest-filename": "extract-zip-1.6.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+        "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+        "dest-filename": "define-property-0.2.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.6.1.tgz#aa97f82d341dfa6f1269d78955482d619cc613ed",
+        "sha512": "5b497ce4efacea539ace25aa021b333dfc221b4b35e45bcc04ff63f62fdb927b0c71c524c0deb4bb80b2ef262d7fa6a40940ee25e9cbaa94d7e3fc6f92ad5e83",
+        "dest-filename": "app-builder-bin-2.6.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901",
+        "sha1": "899f11d9686e5e05cb91b35d5f0e63b773cfc901",
+        "dest-filename": "multicast-dns-service-types-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "sha1": "045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "dest-filename": "set-blocking-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f",
+        "sha1": "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f",
+        "dest-filename": "is-obj-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+        "sha1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+        "dest-filename": "concat-map-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a",
+        "sha1": "bdded70114290828c0a039e72ef25f5aaec4354a",
+        "dest-filename": "ip-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+        "sha512": "882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688",
+        "dest-filename": "brace-expansion-1.1.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9",
+        "sha512": "4be664f0311613aa0aa55faf237a9691a2be8d26c82bcea90b07b6205ff1c08a50f2312ec69c3d3726868e6a7df81a09bf9155da98aa0837280ad4ada698aad8",
+        "dest-filename": "yallist-3.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d",
+        "sha1": "82dc336d232b9062179d05ab3293a66059fd435d",
+        "dest-filename": "indexof-0.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce",
+        "sha512": "a02959237ec7bee50927148a2ab0b5edb67d0aed1962110018fb0f532f4a94c526bfd74a5f6a3bed1526abb7f75e32316f0c86c18cdbcd0d4bd8ab3cb08ada75",
+        "dest-filename": "pumpify-1.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c",
+        "sha1": "7ee8f84dc6fa792d3fd0ae228d24bd949ead205c",
+        "dest-filename": "regjsparser-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+        "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+        "dest-filename": "define-property-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49",
+        "sha1": "7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49",
+        "dest-filename": "fast-deep-equal-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz#68f80695f045d08263a879ad240df8dd64f644ea",
+        "sha1": "68f80695f045d08263a879ad240df8dd64f644ea",
+        "dest-filename": "postcss-reduce-initial-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f",
+        "sha1": "5183bc47a09559befcf98cc4657964999359372f",
+        "dest-filename": "cross-unzip-0.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261",
+        "sha512": "397f17a8feffd5af5caa4c58c36c97b2cd797f6e8d2960690d741dd3fb8afca3ea7508716cf6bdf78867ce3704d95a90a43b257f9e7bdb770a3d43864a6318de",
+        "dest-filename": "debug-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa",
+        "sha512": "32d102d53a8dd045399dea61689e2b02d4e11ed0bce9d34df6a0ae121b6c86fa55064016e593bb04048df5112717d7a85c6711b9bfa916e284a4e1c4f876c433",
+        "dest-filename": "process-nextick-args-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+        "sha512": "36a543bfd4e900d523166d0df2e3391b12f7e9480a8bdfdab59c3ec7b6059d0f1c9301462ab978c57e325adadecb75099b99cfd6451b9d880ba29a963524615b",
+        "dest-filename": "sax-1.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a",
+        "sha512": "619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
+        "dest-filename": "safer-buffer-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991",
+        "sha1": "27d46fb67025c5c2fa25993bfbf579e47841b991",
+        "dest-filename": "color-string-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406",
+        "sha512": "2967e4cbfe7cbee6f0b52d212ea127ad6263b0c19a39e4819fdd04ce7e497a0f59f0a2879842db3f5c86ca53259b937a4cf29e63d036f9469260b7716a1834d7",
+        "dest-filename": "@babel-plugin-transform-spread-7.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030",
+        "sha512": "8beeaa03630f86fa0a2eec6724da57006860ec7a6140e494ab62ca3190f49b5e448ac91752432f29d17852e8b459878250679afa8d9cc3f66ec1e86d7ecacd90",
+        "dest-filename": "util.promisify-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8",
+        "sha512": "41f014b5dfaf15d02d150702f020b262dd5f616c52a8088ad9c483eb30c1f0dddca6c10102f471a7dcce1a0e86fd21c7258013f3cfdacff22e0c600bb0d55b1a",
+        "dest-filename": "color-convert-1.9.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00",
+        "sha512": "eae1d484e3c4060436e0733eafa6ff43059f66afb2885722a4a16b38588112759dcb9b1dcd8a22fa925e41a3c8e6a38b445a969805d43d036c89e97374ba1e70",
+        "dest-filename": "graceful-fs-4.1.15.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279",
+        "sha512": "4ffcefcd845f6d5a233d66a10ec1397af25d1dbde826841f15bb2b28cef0e5972cfbe4ebdb9eed89adc198c3fc5d8563a754bd4595d0321ee06a8f7a065a993b",
+        "dest-filename": "acorn-5.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/crocket/-/crocket-0.9.11.tgz#288fca11ef0d3dd239b62c488265f30c8edfb0c5",
+        "sha1": "288fca11ef0d3dd239b62c488265f30c8edfb0c5",
+        "dest-filename": "crocket-0.9.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6",
+        "sha1": "a157ba402da24e9bf957f9aa69d524eed42901a6",
+        "dest-filename": "tty-browserify-0.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b",
+        "sha512": "99e97e8dfee7aed125e4f9f5431e3acc0457283a416efcdecec7bba7b2ea20d99da0893c3d83f94b249ac44998bfa4d9d09c84280d61b0221de832218084ed59",
+        "dest-filename": "debug-3.2.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1",
+        "sha1": "b17d08d326b4423e568eff719f91b0b1cbdf69f1",
+        "dest-filename": "inherits-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3",
+        "sha1": "f052a28da70e618917ef0a8ac34c1ae5a68286b3",
+        "dest-filename": "pseudomap-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.11.tgz#8377732fe7b207969f264b67582ee47029ce092f",
+        "sha512": "555778d27ae756aca6bc5ad8f5990e6201c93af7b11c7613477762fd237e9a3274396851d48f014558f753e61a9b0ea19e465934a669e76aea2f91050003c591",
+        "dest-filename": "electron-osx-sign-0.4.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz#dd9a1e817f1c2eb105b4cf1013093cb9f3c9cb06",
+        "sha512": "70c5de552f6b8685ec23d2cb2f8b49c418150ff28c38a5ee16a61be68089fe8a52716a6408c133f4426d9289da35c9cbbf64772b98c8792e13463fddadd7b525",
+        "dest-filename": "@webassemblyjs-helper-wasm-bytecode-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz#ab7468befa80f764bb03d3cb5eef8cc998e1cad9",
+        "sha512": "2b3eccb744ac576b5093a8c6e5b06fe698556e477481ddbb4a0603e211f568b30945c84cd1dcc7697beb5a1559f96c40943a00299ed4cb78d54d6da629743559",
+        "dest-filename": "@babel-plugin-transform-for-of-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/file-loader/-/file-loader-3.0.1.tgz#f8e0ba0b599918b51adfe45d66d1e771ad560faa",
+        "sha512": "e2c34839782d1fff5666ae0dbe57d4dcea67e729d4b2a07048bc8cf88ed43b07468a04c161f555404c1efe6b19357fe3e290894c8335e05b30eba4afa35a15af",
+        "dest-filename": "file-loader-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53",
+        "sha1": "365417dede44430d1c11af61027facf074bdfc53",
+        "dest-filename": "path-is-inside-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "dest-filename": "inflight-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0",
+        "sha512": "620e83dd7a510f89243a64e97606d48842452a08491f4ddf882d4e3e597987fd2c3ba9de8768ea443547390e28fcb31e6b4b600a46cc81e6b98a9fdef8c916ca",
+        "dest-filename": "spdx-expression-parse-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c",
+        "sha1": "df604178005f522f15eb4490e7247a1bfaa67f8c",
+        "dest-filename": "path-to-regexp-0.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
+        "sha512": "c88a2f033317e3db05f18979f1f482589e6cbd22ee6a26cfc5740914b98139b4ee0abd0c7f52a23e8a4633d3621638980426df69ad8587a6eb790e803554c8d0",
+        "dest-filename": "function-bind-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105",
+        "sha512": "6351940e8dfd7b3e1a1c0c3b332b27503e49cd85fe59a223f08e7b90edda10f4f57c544be2cafb9a37a2f7b1609f0840cb2cd16264196931dbdbef6e67574fb6",
+        "dest-filename": "finalhandler-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143",
+        "sha1": "4fa917c3e59c94a004cd61f8ee509da651687143",
+        "dest-filename": "cli-boxes-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f",
+        "sha1": "12c25efe40a45e3c323eb8675a0a0ce57b22371f",
+        "dest-filename": "brorand-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b",
+        "sha1": "bd28773e2642881aec51544924299c5cd822185b",
+        "dest-filename": "domelementtype-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+        "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+        "dest-filename": "assign-symbols-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73",
+        "sha1": "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73",
+        "dest-filename": "vm-browserify-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-hot-loader/-/css-hot-loader-1.4.3.tgz#69e8256ef85f2b3b3d89e37f7504c6e3431a70c9",
+        "sha512": "6a49ba80de7bb028ab00142e4fe05920759ffd46465f4cb8ccc9eb6d920a38fc93769836fad78ff644374ad062e1df9b65b7495865bbf159ac82d5c1630e2e90",
+        "dest-filename": "css-hot-loader-1.4.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz#108f74b3f2fcdaf891a2ffa3ea4592279fc78222",
+        "sha1": "108f74b3f2fcdaf891a2ffa3ea4592279fc78222",
+        "dest-filename": "postcss-normalize-url-3.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7",
+        "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
+        "dest-filename": "fill-range-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a",
+        "sha1": "f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a",
+        "dest-filename": "minimalistic-crypto-utils-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c",
+        "sha512": "61f437b501532bfcb394626e5fca53c1ae2d89f423e104b6323ed47a03aef23033e7d32a2223063d7c5085542220c3736b2b94485fe312e5677c517926ac9b99",
+        "dest-filename": "source-map-support-0.5.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe",
+        "sha1": "b968c6b0a04384324902e8bf1a5df32579a450fe",
+        "dest-filename": "get-stdin-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1",
+        "sha1": "df010aa1287e164bbda6f9723b0a96a1ec4187a1",
+        "dest-filename": "array-find-index-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/progress-stream/-/progress-stream-1.2.0.tgz#2cd3cfea33ba3a89c9c121ec3347abe9ab125f77",
+        "sha1": "2cd3cfea33ba3a89c9c121ec3347abe9ab125f77",
+        "dest-filename": "progress-stream-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801",
+        "sha512": "c3f86bcbfdfaf273b6d4037d4258ec68885bf59899b59011a151f97f70ac15b6b074b75ac8280a44fba9ec2820ba3bf248cc71d08f7534ecb175510da21a6b2d",
+        "dest-filename": "vendors-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz#0d5ad15dc805e2ea866df4dd6682bfe76d1408c2",
+        "sha512": "901f7e861522748814a0143432cc4c7b0873afc8bad2731ad8a81e24a41662ba90a6a70162d9e947e26091a759559a1a119fde2aef6672515a570851a4b352cc",
+        "dest-filename": "@babel-plugin-transform-parameters-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz#912bfe9e5ff982924c81d0937c92d24994bb9068",
+        "sha512": "698270a408682bd6bed7e3badb95888ef318d75c2407fa24d160a557099ea379828dc3518edfbff201d6ac1e62fb4d26523bb4816b019109cfa5dbd0ecf22699",
+        "dest-filename": "@babel-plugin-transform-modules-systemjs-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
+        "sha1": "b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
+        "dest-filename": "merge-descriptors-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69",
+        "sha1": "458b83887f288fc56d6fffbfad262e26638efa69",
+        "dest-filename": "term-size-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz#b2c6a98c0072cf91b932d1a496508114311735bf",
+        "sha1": "b2c6a98c0072cf91b932d1a496508114311735bf",
+        "dest-filename": "postcss-minify-selectors-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7",
+        "sha512": "52d25c003e3211a1ad8cf7b35ae3bdc02e27c149d51fff3f226df210740fe1bebb717943fd0afd85d213094d710db4845e0d9728d68ff23b11795eef41dd34fc",
+        "dest-filename": "minimalistic-assert-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6",
+        "sha512": "288d7ea8e66ee43716eb06b26074b347fb572820c2e4e9b8b35cf64098c350bccb7267f70efcd2ee896e6381c24eb73ef4588a99652078d2e0ed6dee210bf1b5",
+        "dest-filename": "mime-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4",
+        "sha1": "0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4",
+        "dest-filename": "content-disposition-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz#25bd117562ca8c002720ff8116ef9072d9ca869c",
+        "sha512": "944c950a0da7a75e6d4be766efe2494cd84d5aaf724d9be2dea12100820e6a87dc625529d14479fed56a3b06bf81762bde08f0499ab0fbf952f5db1cc8b7a56d",
+        "dest-filename": "@webassemblyjs-wast-parser-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036",
+        "sha1": "8ef5b7de50437a3fdca6b4e865ef7aa55cb48036",
+        "dest-filename": "is-path-inside-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898",
+        "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
+        "dest-filename": "is-binary-path-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b",
+        "sha512": "afacca00230d8633c931397c29c147e258bffe092b5d67db0fa7de57c97a768447973963156189d803fa88a682257c9998050c38fb6f6d6ec45e46d63bfa4b10",
+        "dest-filename": "p-map-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764",
+        "sha1": "6d7b5c74fb65e841cd48792ad1ed5e07b904d764",
+        "dest-filename": "color-0.11.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
+        "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
+        "dest-filename": "require-main-filename-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a",
+        "sha1": "ec6a61ae56480c0c3cb241c95618e20892f9672a",
+        "dest-filename": "async-1.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cacache/-/cacache-11.3.1.tgz#d09d25f6c4aca7a6d305d141ae332613aa1d515f",
+        "sha512": "d8f130e1c4510eefa242f0534eeb6d4227da7188cb3e1113f9260efe0105332f2e862fa39494440c08d217915649d57f030e61d7c71a1c0eef313c3673ec03cc",
+        "dest-filename": "cacache-11.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a",
+        "sha512": "58928539531e025b14fe98d7baa55dcd4d167e0b48042ba99045709fed58d044406d47d6c3c4781a38156da2a75234680f616841b1ce09b3b24f931bb3d2f0e2",
+        "dest-filename": "npm-packlist-1.1.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+        "sha1": "bb935d48582cba168c06834957a54a3e07124f11",
+        "dest-filename": "isarray-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d",
+        "sha1": "d933ceb9205d82bdcf4886f6742bdc2b4dea146d",
+        "dest-filename": "map-obj-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz#6c90542f210ee975aa2aa8c8b5af7fa73a126953",
+        "sha512": "80466f813cb556d70339a42dcb5975d13de342624a94d5712c30acfb7ac254fafa9cc90e0cb10bc558aae57f65fab7f16e27b75eb7eb30261863a797dda39c39",
+        "dest-filename": "@babel-plugin-transform-classes-7.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317",
+        "sha512": "300155d4203f615998c191b47c14325e19a3d011c20797a064708a588155bff5c2c407951881dfa2cdd2c03724e0bbc296510d20083bc4c28e1b9907d1dcf252",
+        "dest-filename": "@babel-plugin-proposal-json-strings-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7",
+        "sha1": "f0d66d03672a825cb1b73bdb3fe62310c8e552b7",
+        "dest-filename": "detect-file-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600",
+        "sha512": "ba6e3a841f7034e2a5c241e08aec84540c9b5c18f015457467f45a1c96e545df435e5b6e7bd15362fcc2afd12b42b2bd01dcf9314e201d655a3547dd9ab0bca8",
+        "dest-filename": "js-yaml-3.12.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz#cf8f106e746662a0da29bdef635fcd3d1248364b",
+        "sha512": "4fc1120bd28c5c54d7039bab25cca8af9727eaa59e678ff32cfc967845d9d37863ff1f70792a2418d91509d9e149a6ca1985b112549d809fac15af46fd174737",
+        "dest-filename": "@webassemblyjs-helper-code-frame-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.0.4.tgz#aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298",
+        "sha1": "aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298",
+        "dest-filename": "browserify-sign-4.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9",
+        "sha1": "d501f97b3bdb403af8ef9ecc20573187aadac0e9",
+        "dest-filename": "xmldom-0.1.27.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1",
+        "sha512": "3c8b76727c263df2f884a370a9e8aecf86ca7e7cc74c1bfa1f25608da840ea63cbc0f0f38c35aba652413231d417192efcddc5966adbc8f72569df88fb8989dc",
+        "dest-filename": "js-yaml-3.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df",
+        "sha512": "e40cc5cdda0831bf3d84118c6609447a07dfce0460f991685268ac43c1c8e23d4a0dda71d77274b5a369db2f713dbbabe96eb581ea460c3a2d181550ee67d40a",
+        "dest-filename": "node-libs-browser-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d",
+        "sha1": "9876dbd2a169d3115402d48e6ea6329c8816a50d",
+        "dest-filename": "speedometer-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550",
+        "sha512": "111efb09ac75fbcffc8c207d7e8e14775eb5399cd6379a9ac22e06bac0ee44b7036c31be6c8198636d336f675f005753446ceb7eadb164fbc5d11eb81079e29a",
+        "dest-filename": "@babel-plugin-transform-arrow-functions-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe",
+        "sha512": "f1922d2c778481aa84bdde656015df9b8119485097dbd25bf4afa50078432b345e28140a8f747eecd385ead8ea622f6de2823c5547da5884c9426f3ac275c635",
+        "dest-filename": "mixin-deep-1.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494",
+        "sha512": "8f7f04bcee7e2c75fce23968ea1e14ce63b08b45205bad564723ed273e2a69a74ae5e6370534b94d8fd2d52b5cdd493694833a4cf7af02550b88427089ef3ad2",
+        "dest-filename": "chownr-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf",
+        "sha512": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+        "dest-filename": "loose-envify-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz#a69f0af6502eb9a3c045555b1a6129d3d3f2e313",
+        "sha512": "cd8f1d48dc98720ccd44d4faebaff33a8032226b219b7c9c29da0bb320f0fc1c28ebefee92d6fba78c72029b9e7f5770101a3f53f4984336c606f57e9ebbb65e",
+        "dest-filename": "@webassemblyjs-floating-point-hex-parser-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+        "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+        "dest-filename": "collection-visit-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c",
+        "sha1": "f5a6d70e8395e21c858fb0489d64df02424d506c",
+        "dest-filename": "globby-6.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6",
+        "sha1": "06be7abef947a3f14a30fd610671d401bca8b7b6",
+        "dest-filename": "create-error-class-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-webpack/-/electron-webpack-2.6.2.tgz#6727944eef2a6dc8e483e34e5da756903c501965",
+        "sha512": "fdb97d14846b939ff308fd0cc91075d2ca87088156b2e005d10be1912d246fe6fb7b3442798eabbbc734bcee6456defa5d963bd89b15604c0faab6ab033dfa66",
+        "dest-filename": "electron-webpack-2.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c",
+        "sha512": "d7016e31420cd7a3032510aba5ba6e10f4d41a633940c520d1caf7285c2b6b65e03a015c3c60d01c38770accd2083d997b073f761fe96a63445bc09b7c379b53",
+        "dest-filename": "v8-compile-cache-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d",
+        "sha1": "8b55680bb4be283a0b5bf4ea2e38580be1d9320d",
+        "dest-filename": "http-errors-1.6.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4",
+        "sha1": "f2fb63a65e4905b406c86072765a1a4dc793b9f4",
+        "dest-filename": "is-npm-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac",
+        "sha1": "9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac",
+        "dest-filename": "lower-case-1.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4",
+        "sha1": "4e492f8d04dfb6f89003507f6edbf2d501e7c6f4",
+        "dest-filename": "faye-websocket-0.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da",
+        "sha512": "90ffddaea4f163a5eddcd3692a232899f824367e28efebcac4ad830ca7011bdb078f9d6f1ea3011b2f306c34bf27894cc67aacd79dff4f7f83982100902e5ca4",
+        "dest-filename": "@babel-plugin-transform-computed-properties-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a",
+        "sha512": "4daaa7fb79cdbd845f2776c6bca7c1491c32d6fe9e78f966de873f696571669e7b0d0af912adf184a262ed9e216694bc3c2dc7e2a23e625cb912615a706b80fe",
+        "dest-filename": "http-proxy-1.17.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.6.tgz#d302c522948588848a8d300c932b44c24231da80",
+        "sha512": "088439385c5fe09a2eeae38a7bdb7500e82aa5e5397ddef403c34f7474867985ea5ec3deea978ec08d1c525f3c45667ab0fd6f3cc5776af77f47a719e7fb0fd4",
+        "dest-filename": "randombytes-2.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs/-/yargs-12.0.2.tgz#fe58234369392af33ecbef53819171eff0f5aadc",
+        "sha512": "7bb4a4131e8de92219e5ce47db645365a7bad6ab67dcf61413c2586c11652bdb189a1dc3310e84e7282d686ff6056d09662e161a04d1d885790a1aa5aab0c655",
+        "dest-filename": "yargs-12.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mem/-/mem-4.0.0.tgz#6437690d9471678f6cc83659c00cbafcd6b0cdaf",
+        "sha512": "590c46ff9c58737b4c6d82d7a173e6f35113d960d42e25391716ee22835b26a2ce388f337a15c5759ba250481f76b536995075a710595069583914aba6e26b78",
+        "dest-filename": "mem-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a",
+        "sha1": "3c531942e908c2697c0ec344858c286c7ca0a60a",
+        "dest-filename": "strip-json-comments-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3",
+        "sha1": "5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3",
+        "dest-filename": "pretty-error-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf",
+        "sha1": "cfedf88e60c00dd9697b61fdd2a8343a9b680eaf",
+        "dest-filename": "throttleit-0.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2",
+        "sha1": "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2",
+        "dest-filename": "jsprim-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef",
+        "sha1": "c24bce2a283adad5bc3f58e0d48249b92379d8ef",
+        "dest-filename": "remove-trailing-separator-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+        "sha1": "34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+        "dest-filename": "has-ansi-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf",
+        "sha512": "8e2f6ac519ce55f72e2c3c928fdab3846484155a1bcadd6420e4a48f5a99cd82f3abb4e8b3fa14516be8b543d02e5aec89daac2bab411fcf4173d90be731c0eb",
+        "dest-filename": "stable-0.1.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz#ff76f4d8212437b31c298a42d2e1444025771ae1",
+        "sha1": "ff76f4d8212437b31c298a42d2e1444025771ae1",
+        "dest-filename": "postcss-reduce-transforms-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz#c2c6d20cc958284f6abfbe63f7609bf409059ad3",
+        "sha1": "c2c6d20cc958284f6abfbe63f7609bf409059ad3",
+        "dest-filename": "postcss-reduce-idents-2.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d",
+        "sha512": "68ffe194bab4d4358d1220e0e099f6de2f825f15bfa303385a90cb1546e98f17b8352dc184b5594398bb13466bc6e43fbf07a421e722c9a9a0075508631c4ce8",
+        "dest-filename": "@babel-helper-module-imports-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1",
+        "sha512": "bdc7ee888c6880b5780e51811c850ec08d086eb27c1d63dce0c53b1f3be219e361a3f5090df8ba079a77b07796210d0a188534269c62e591f17a641f2e4900c1",
+        "dest-filename": "glob-7.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080",
+        "sha1": "0162ec2d9351f5ddd59a9202cba935366a725080",
+        "dest-filename": "compare-version-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770",
+        "sha512": "8b6ecc89ce0aa2f33f9671accbcc214421e173b5627096a30234eb620d752bdcdf6579d822de24e45fa4664c239eb84accb89cfc72d4e23d759a3b33d86ffbe6",
+        "dest-filename": "schema-utils-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952",
+        "sha1": "d5c752825e5367e786f78e18e445ea223a155952",
+        "dest-filename": "stream-shift-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff",
+        "sha512": "19b10740f30eb301a929733d902595aeb7a651c0668ed794690d354fdae42823c35df5075f42283fd2e91d8a3634f15a9a96b87befe91437378d0771af140b6b",
+        "dest-filename": "create-ecdh-4.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz#82245fdf82337041645e477114d8e593aa18b8ec",
+        "sha512": "4f9dc6545b1d8a72618309bbae0d41cdb78146898e83dcb930156119cb15d02c6ead47558f55253dd2ad9fb6aa600fdcfd0564cca323ab66d257974a1b9f80c1",
+        "dest-filename": "postcss-filter-plugins-2.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.2.0.tgz#8335f3140f3144270dc63c4732a4f8b0a50b7a21",
+        "sha512": "16bd3b37e79ad1d31c30df27169b8ae9d5084fbfe2bedf722907441278d54bcded1b6a47c0f8b4de062693fb72bb038d9d9fac63e18514f9561a00ad5b5845f4",
+        "dest-filename": "@babel-helpers-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777",
+        "sha1": "944becd34cc41ee32a63a9faf27ad5a65fc59777",
+        "dest-filename": "execa-0.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790",
+        "sha512": "0d7f272a0a9c1b0b1cd1e252a98b799703f80c7e459479e6b96581472ed7d0d71a191d19b6ec9e11280cc1361512dc66b0d198faa8ade10613fcc2184ce4cf78",
+        "dest-filename": "@xtuc-ieee754-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.38.3.tgz#7c162904f728ba2bbf2640bc3620b65ce1061ce3",
+        "sha512": "4289aadb9dcd4f90df8d4660152c7aa7e821794e5884ceb367aedf4ed059bf0ca4d2ff07c313577daf1f653ee1fb57370701268eeb136e68d944d5bf5d905714",
+        "dest-filename": "electron-publish-20.38.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259",
+        "sha512": "323aacbcdc32cf5b3493cd46a33ffdbd105ef5265d074f41770fbfcd8c8efb70ae3e4e9fa2e4dac6c707920b44f232af7f4d6455f97cae21f311143f91e7da48",
+        "dest-filename": "source-map-resolve-0.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed",
+        "sha512": "cb76c682a2a3dd005dc4b6cb9289a5a2192fb00f207408944254812670617e7f813f18386dceb677c4dc056d79c1abc37e07b10a071c72485c66fcb0c9060f3b",
+        "dest-filename": "rc-1.2.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184",
+        "sha512": "ffaa6de3e0be4fec1952278a47adb43a9ccdfcb96734ab968f2d6214b43f506df926a1e547ff3d30fd5df7a7547e47fa0e77b74ee2d0cce60462c849f87c7c9b",
+        "dest-filename": "psl-1.1.31.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tapable/-/tapable-1.1.0.tgz#0d076a172e3d9ba088fd2272b2668fb8d194b78c",
+        "sha512": "225aad98b55a640daa69bf1ea545db556467dda0758a66c3309b630779eee17d0da8f91c63f247f59b4205628758fc6cf12be2f6dca8f30d9d0688b4eea65b04",
+        "dest-filename": "tapable-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e",
+        "sha1": "813584021962a9e9e6fd039f940d12f56ca7859e",
+        "dest-filename": "ansi-html-0.0.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7",
+        "sha512": "fea28f51095a5b53b2479d567823c1bd19c0967645509902486e47cc69ee22a860c89b45f93f789459e7df77a26b38d19b62c01d5cb682e3676aae3c5fd489bb",
+        "dest-filename": "bluebird-3.5.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
+        "sha1": "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
+        "dest-filename": "assert-plus-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64",
+        "sha1": "31ea21a734bab9bbb0f32466d893aea51e4a3c64",
+        "dest-filename": "kind-of-3.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97",
+        "sha1": "d2f0f737d16b0615e72a6935ed04214572d56f97",
+        "dest-filename": "unzip-response-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff",
+        "sha512": "56f8af32b6ef7769ca9221b7f2a8d42f395cfb8571e309bfc2123da500f7e58ac044d9e1c5e89192d48e852ba444b14d97383a06bfdc24f7ade49feed7daff9a",
+        "dest-filename": "private-0.1.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz#ef9ee71212d7fe759c78ed162f61ed62b5cb93f1",
+        "sha1": "ef9ee71212d7fe759c78ed162f61ed62b5cb93f1",
+        "dest-filename": "postcss-normalize-charset-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f",
+        "sha1": "eb3284da4ea311b6cc8ace3653748a52abf25a3f",
+        "dest-filename": "through2-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.1.tgz#f6bf293818332bd0dab54efb16087724745e6ca8",
+        "sha512": "28fc7b7e529783bef9cd9a67a7d4b1265cf4d204dde01989db226e7d2738e2030246b450ecd4b301c48941f89fb8e2e05ba6c48be7edac02edb2000b781d8077",
+        "dest-filename": "parse-asn1-5.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
+        "sha512": "4d3958a5af8e2febcc30d1b6e314a5406109dc1fd1cc47d494b72dedbe46ff2b5abfec0fae9942a55305bb0cd76e479c26b6fa218a358856f44bdbf7efbe789a",
+        "dest-filename": "ret-0.1.15.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2",
+        "sha512": "1533321549b6c017061e71f67979b3eed0ba23096a419ea6559fba766eaf6782102078ece8574db1006e2863ee514518e8d7c9c363ec842d3c4e7e8bccb0ce6a",
+        "dest-filename": "object-keys-1.0.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93",
+        "sha512": "e5eae2a3687d8e9e421c6c1cc9b9b1995a879a708165e7b095f274a5ec7e516ed09f2ece3995d3b47e7a4c6372062ce48223b0849b4c2ab5730d378a732499c0",
+        "dest-filename": "proxy-addr-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445",
+        "sha1": "b319c0dd4607f353f3be9cca4c72fc148c49f445",
+        "dest-filename": "global-dirs-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84",
+        "sha1": "0a22e8210609ad35542f8c8d5d2159aff0751c84",
+        "dest-filename": "pretty-bytes-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.6.tgz#001303cf87a5b9d093494a4bf251d7b5d03d3999",
+        "sha512": "6ebc0f06d56f758746c6d7a76d081f09d0cf9ad92650164f8d4a0ae525c9101b87680e410ae6e1f65cbae5fcd7cfb47aa39ac0efa46cdb6112f19f8709cd1821",
+        "dest-filename": "@babel-generator-7.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
+        "sha1": "35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
+        "dest-filename": "npm-run-path-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3",
+        "sha1": "da42f49740c0b42db2ca9728571cb190c98efea3",
+        "dest-filename": "shebang-regex-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925",
+        "sha512": "5cafaebfd916c2164c675cbb9b2b01fb3a2286c123e309de156012e6aa222f0cd6d16cd2a8caebb08cbe6b7ce4409ab48a916d0695f95b732ac9120117f5851a",
+        "dest-filename": "style-loader-0.23.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165",
+        "sha512": "0bc171ff48c5995e483e830e14f03d3fd1b936da96fb870e3e2b77308baf476b7b020d8ad791094e9c671c0613ccbf9a61024811261e5d998305f3811351dca4",
+        "dest-filename": "es-abstract-1.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7",
+        "sha512": "8db457cb5166b40a028d0915988558c2ebaa0c551b68e7838e679dd6d3863ebb0c86d240e2b0fdb64800d05d6a2778111515dc1d856475e68fe74439ac4fe32d",
+        "dest-filename": "is-data-descriptor-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b",
+        "sha1": "ddd800da0c66127393cca5950ea968a3aaf1253b",
+        "dest-filename": "commondir-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6",
+        "sha512": "53f8a5e4cb2b669ee61a0de64907e7ef8da76b64fed7fbc70c21b9fe24c8dd7f4c294b9851954b421c91b20d3a982803053779ed3c73819b7b3fe7d87e344bb4",
+        "dest-filename": "pbkdf2-3.0.17.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+        "sha512": "786b85170ed4a5d6be838a7e407be75b44724d7fd255e2410ccfe00ad30044ed1c2ee4f61dc10a9d33ef86357a6867aaac207fb1b368a742acce6d23b1a594e0",
+        "dest-filename": "esprima-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "dest-filename": "once-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.1.tgz#9638047e4213f3428a11944a7d4b31cba0a3ff95",
+        "sha512": "5edfb36fa9ea82f57d496015a74106de546c1dc6eae430e0aa33cfcfaa7082d8fa44acfae7319730d6bcda825f392040feda3a1a644fec3afeea8fa46c0a53cd",
+        "dest-filename": "ansi-colors-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598",
+        "sha1": "f6b4501c2ec4cdd26ba78be7222961de77621598",
+        "dest-filename": "upper-case-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f",
+        "sha512": "c62b4ff96c4d3dc4d33a09d325cae1334c6f74f7a98a93d27f723c108a4629e14b8eddcf9492c80c6deef045f9dd922e6e46fee54dbedeb10b6291211e1cdd92",
+        "dest-filename": "md5.js-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927",
+        "sha512": "45963986e20a08c4560d4a999448bbd9ffe599728cbeeb3370c05dba5890de79d66f1f57fd90503bb0e28cc1184bd1211c16f6a9a71150cb42eecbcbc1ed2573",
+        "dest-filename": "ini-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb",
+        "sha1": "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb",
+        "dest-filename": "cookie-0.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000928.tgz#805e828dc72b06498e3683a32e61c7507fd67b88",
+        "sha512": "692a4c5915cbe995cd9f39bc8601384032e26c6e69549d948f3b2e8f789c6b39489315e43d7b4bf815a7331e850645a69198011c65313d942fadb470d994f186",
+        "dest-filename": "caniuse-lite-1.0.30000928.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36",
+        "sha1": "4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36",
+        "dest-filename": "semver-diff-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36",
+        "sha512": "3796405f8fcbc49985fbbc0def8a540faa8087dff09ef750723abd4d98debef5f3494a3b6df9b0f75b1aa8c8f3192db1abdd7fa1d376756fd63a5eea40734318",
+        "dest-filename": "qs-6.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0",
+        "sha512": "d9648b6ba39d61dda783ca2a8862169c9ab2140aef867fb9be0c79193c4c6d462309829472e292eb660b145d11fc10c6941d72cd78d038bb4f01f1ec822ac4a6",
+        "dest-filename": "unicode-property-aliases-ecmascript-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f",
+        "sha512": "67de36472b075e626b86a93cf0598a055abfbf9b6a992903cfba79e06fcc1b28cc9c21459c2efd5d635b83e56d6bc5ba59bdaab526534b1206909ad1a4214488",
+        "dest-filename": "browserify-zlib-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67",
+        "sha512": "7e1fa902ab78c51ccf7ea03a7a1dd9db2e9fc996af448ba6be385a08bef9dfe4d59062868693decab246d897ed0f44fdab8185d342a379fb10f8f40d0dd59069",
+        "dest-filename": "@types-node-10.12.18.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "sha1": "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "dest-filename": "strip-ansi-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b",
+        "sha1": "eaf439fd4d4848ad74e5cc7dbef200672b9e345b",
+        "dest-filename": "date-now-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-loader/-/node-loader-0.6.0.tgz#c797ef51095ed5859902b157f6384f6361e05ae8",
+        "sha1": "c797ef51095ed5859902b157f6384f6361e05ae8",
+        "dest-filename": "node-loader-0.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182",
+        "sha1": "7332300e840161bda3e69a1d1d91a7d4bc16f182",
+        "dest-filename": "process-0.11.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9",
+        "sha1": "3a83a904e54353287874c564b7549386849a98c9",
+        "dest-filename": "ecc-jsbn-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.2.1.tgz#779c696c82482491f0803907508db2e276ed3b61",
+        "sha512": "8de26f787c33fefc2927707c6f110be5afeb54a22944d243b0a8207ca9f1b987a884d0d6e18ff007d37f5c7240d3ddea6724b4afa9982fefdcacbb08a25e1628",
+        "dest-filename": "webpack-cli-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0",
+        "sha1": "240cd05785a9a18e561dc1b44b41c763ef1e8db0",
+        "dest-filename": "got-6.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.4.tgz#a000bb07e4f57f412ba35c904d035cfd4a7b9446",
+        "sha512": "5afb9269329752a6096e74fb47762bb0dac7bff0b9bd17ebe558254b86c53a4d0c613e022c17dcff1804c40fb1d917ed958822043bd6995b35f755eff12f2065",
+        "dest-filename": "postcss-modules-local-by-default-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195",
+        "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
+        "dest-filename": "is-number-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2",
+        "sha1": "ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2",
+        "dest-filename": "duplexer3-0.1.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5",
+        "sha512": "bbc9ddf4d41e3d835057c88f5aefe92cb601a9905ae19698d5859114cbb1ae277de30288d5036debb34467b1807b929cff42cb49c6e29b4e716455a401dae3f6",
+        "dest-filename": "@babel-helper-optimise-call-expression-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612",
+        "sha512": "995c6e27462ba08fe1fed6c54cf19947c72fe9a8be49330a341ab47fc845c6cc568e5f78aaa86c6fec176e934c0cf53771f4754c8b151735379d7c9932ac8ae3",
+        "dest-filename": "@babel-plugin-syntax-dynamic-import-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd",
+        "sha1": "a9ef153660d6a86a8bdec0289a5c684d217432fd",
+        "dest-filename": "coa-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1",
+        "sha512": "dcca9f60a8f694bcdd3127fc648644fd5f99bb2f81803e9fd7ae1ef0adb0edd827a4a02b0437ab198a4ce3a21861c8e791d3cd3233e4f40e95141f3edd22a55d",
+        "dest-filename": "define-properties-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285",
+        "sha1": "290cbb232e306942d7d7ea9b83732ab7856f8285",
+        "dest-filename": "setimmediate-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21",
+        "sha512": "e6161d024665706f2d38bba35434e0093fae3d7d159e9007dbc816b0b7f3a57626ef03fa9a9e50fe063247b610d1c29525c5c99e5de3da4a416a7d773ed41feb",
+        "dest-filename": "are-we-there-yet-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50",
+        "sha1": "7a57eb550a6783f9115331fcf4663d5c8e007a50",
+        "dest-filename": "pend-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b",
+        "sha512": "1a0b8ff83458fa9277b28c888863d3bdd8955e367e0db5cec46a579f778cbcd5b8c788ab8ea5e6e301cab1c0be4dfc52274cb0fd2d45db8b6a74c36c3194e22c",
+        "dest-filename": "ieee754-1.1.12.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz#d1df5dfaa7b1acc3be553f0e9e10e87c61b5f721",
+        "sha1": "d1df5dfaa7b1acc3be553f0e9e10e87c61b5f721",
+        "dest-filename": "postcss-merge-rules-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73",
+        "sha512": "d720fa4662c8d5705fc6e82f391c25724e9fef9b582fe891d23ab0b0eacec4c672198a94b83849d25e005dd3b5897fc54ecf5c040304935816484c759126f296",
+        "dest-filename": "find-up-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424",
+        "sha512": "32d8be7fd96924d730178b5657cfcead34ed1758198be7fc16a97201da2eada95c156150585dbe3600874a18e409bf881412eaf5bb99c04d71724414e29792b9",
+        "dest-filename": "chalk-2.4.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4",
+        "sha512": "398bbb5c4ce39024370b93ecdd0219b107cda6aa09c99640f7dc1df5a59dd39342b42e6958e91284ada690be875d047afc2cb695b35d3e5641a6e4075c4eb780",
+        "dest-filename": "jsesc-2.5.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz#a63868289e5b4007f7054d46491af51435766008",
+        "sha512": "ba6878851e8dee6bb8125abd186f133aef4cd1b6a4be5b111040be89a96b40de80052e280d0ebda89bf556d477bb194a30240c0afce4eefaf5ed11ca723c7af0",
+        "dest-filename": "@babel-plugin-transform-exponentiation-operator-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz#ac0059b02b9692515a637115b0cc9fed3a35c7b0",
+        "sha512": "22e68b8ebb8cd2f30a854513e757d0750cc16135f8f5d2e3f30ebc00b1007b6038898369202e1e31a73aee6b77373c9cbe33a57f4eff918c490dcd114e5d56ab",
+        "dest-filename": "mini-css-extract-plugin-0.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e",
+        "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
+        "dest-filename": "safe-regex-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476",
+        "sha1": "d3fc114ba06995a45ec6893f484ceb1d78f5f476",
+        "dest-filename": "prr-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb",
+        "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
+        "dest-filename": "is-fullwidth-code-point-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e",
+        "sha512": "3d7d70bb402601d3ea38bd665a1aa694e77c90e219430199c3aae1eee6f2f5f4dce6585a39614b5f723a47586b17d937cd4638d1eea282c2c69035caf762c936",
+        "dest-filename": "obuf-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63",
+        "sha512": "9dec9351516d6a18dfd260777594fbeeefbc3b4401f3d8c57670647793f526060f6cf6a26b78175ce54bd9fabc57253680c303ed268ded0ba44c1fe999762f0c",
+        "dest-filename": "iconv-lite-0.4.23.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.1.tgz#5e9edc6d1ce8fb264db18a507ef9bd8544451ca6",
+        "sha512": "9fd714ebe8084da56eed51a3d59f1f78a3267c08c40101a1c03f5f137cefa5145ad30108c7c3836245467d273de0cd8e5f4d2d50557cc07df361b9b523c9b116",
+        "dest-filename": "unique-slug-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d",
+        "sha512": "553d1923a91945d4e1f18c89c3748c6d89bfbbe36a7ec03112958ed0f7fdb2af3f7bde16c713a93cac7d151d459720ad3950cd390fbc9ed96a17189173eaf9a8",
+        "dest-filename": "ansi-styles-3.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.29.tgz#3fa9d4ef3142cbd1c301e7664c1f352bd82f5a39",
+        "sha512": "b1135bd57c9dc245bd20e722ea2076c66cbc2060a3eabfdfafe2568adbc9d89c5044fccddd3e0018655608c955995c0cd60b6000b2519862255afe69a6718692",
+        "dest-filename": "css-tree-1.0.0-alpha.29.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+        "sha1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+        "dest-filename": "is-arrayish-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286",
+        "sha512": "e24ac5f2c7297a385a3a0ab304470633bc832047e2d3ff3ef330d166135967692398727886fdf309b416c68246cf58b0e54d099749e66b5df1cc75dc9dc31abd",
+        "dest-filename": "tslib-1.9.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66",
+        "sha512": "ac125e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492",
+        "dest-filename": "universalify-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f",
+        "sha512": "1b62e3eb5b570e754514e8bc55976cf92a108ed402ddd82890a7431b69939b5b71e26e743541c1399481c10407cb2d15d760342531b889c7d9407fb13f287c54",
+        "dest-filename": "lowercase-keys-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4",
+        "sha1": "5b292198ffdd553b3a0f20ded0592b956955c8b4",
+        "dest-filename": "body-parser-1.18.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/htmlnano/-/htmlnano-0.1.10.tgz#a0a548eb4c76ae2cf2423ec7a25c881734d3dea6",
+        "sha512": "793114cf3f15756629fb0fca51d6fdf64c1aa38ade47ae1ea54c92c9991079ea5ccb33d0da7d843d6ce26dfe900f19a41b2d742abf822b162a2378b349b9a125",
+        "dest-filename": "htmlnano-0.1.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035",
+        "sha512": "605f4c35d572ff4aaf26f0edba700ecc5c3d89ab0e407a55b614c2bc6cf1b7ad4897ae0061219d2bead8c2577b3407e4f6a27b76dfa1ca604d49cf4b3584be4b",
+        "dest-filename": "opn-5.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz#361d80821b6f38da75bd3f0785ece20a88c5fe7f",
+        "sha512": "ddf38ad0bf8576583c4b96a5f2efe1584eaf86e7c64a7d1b374f719b62d7332fff444005f240c2ad8a0e04a62603c9b93689beb15f4bc8b0b0ac5ca703cfec96",
+        "dest-filename": "@babel-helper-remap-async-to-generator-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2",
+        "sha512": "d8b361113598c62632b01b6b053a8bf3e2dad232284109c849c50973be0e62f50646692c90d6381332c29e31c1cdd99bdfcc2ab536a2c69a3535cb4472f30367",
+        "dest-filename": "@babel-plugin-transform-typeof-symbol-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520",
+        "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
+        "dest-filename": "arr-diff-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0",
+        "sha512": "7f676899df5fb150c5b5a15c6da459b985f0b5d9a7cea6c00d2c21496631601fd0f33b1d51414c5d54705c60cc5a66c4cc09f591d46bb48d53fca4c538be17d8",
+        "dest-filename": "copy-concurrently-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a",
+        "sha512": "6c9cf1ea73283fa3c32cf0459a0efec5129e159bc56e832b1a5c66363f4296f5f9dcaae6bcce5b5c55c45a36f3e1ccf50059fe8d627dcff0c94b3ee1aecd30df",
+        "dest-filename": "map-age-cleaner-0.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af",
+        "sha1": "82d79bff30a67c4005ffd5e2515300ad9ca4d7af",
+        "dest-filename": "lodash.debounce-4.0.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0",
+        "sha512": "4c433688c20441d276ca33c9a1222c95d9e5795680935a16dc305553293238bb04b0598473d927f921453f3fa0979e0a40dc650e7030097a2c392f4e931db102",
+        "dest-filename": "buffer-alloc-unsafe-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-5.3.1.tgz#77bae7ca928ad85716e2fda42f261bf7c1d65b5e",
+        "sha1": "77bae7ca928ad85716e2fda42f261bf7c1d65b5e",
+        "dest-filename": "postcss-calc-5.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.3.0.tgz#3c326da7fcfd69fa0d332575a41c8c0cdf588c96",
+        "sha512": "cf36bbda8641047cedeb81bb0f176aacea3fdf46e11e4c0c5284f45aa7c6bbdf172ddecdfb5b6ccb9309f7a064e0c0f4cbbe27eb6f51866ac65ba5e59cb2f008",
+        "dest-filename": "regjsparser-0.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250",
+        "sha512": "09800e502011c04c67122c4b741eac0e6d9d209fd880400a0ccd4c39e31e66ef4b77f6c3815a3c6a25ab5f0718ece061fb511adae51c5517312a4d0626f5bb40",
+        "dest-filename": "@babel-helper-plugin-utils-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3",
+        "sha1": "97a1119649b211ad33691d9f9f486a8ec9fbe0a3",
+        "dest-filename": "alphanum-sort-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8",
+        "sha512": "542232475c09a0405952a9393c0fa838117aca96f087968d077239d20bb100bfeaba081d7ece13b4d1d0ad26b3140ddf619fad12a7ecd3320696fd1cfeb8236d",
+        "dest-filename": "yargs-parser-10.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c",
+        "sha512": "8a2e226a08b6e56bac568882e01e25abba5b5df029dc3f6fe42c1f918df7bdf7f0dbea640e36350fc19a37bb29b31bc24b1f1d90fa8e642119c9fc5c9891b620",
+        "dest-filename": "ripemd160-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187",
+        "sha512": "bff8b053ac2fc062bc1db53dca2dff9e11b33f4c864ae8503332fac9289e735152ad96439219b89e83925b3acd168fe311cf92258ea3453c2ec1b49724f0d49d",
+        "dest-filename": "schema-utils-0.4.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619",
+        "sha1": "df3ae199acadfb7d440aaae0b29e2272b24ec619",
+        "dest-filename": "delayed-stream-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz#ae8fbd89517fa7892d20e6564e641e8770c3aa4a",
+        "sha512": "ca29f4ebd1588da87e2dba9f19e4dfcc804e0dec7f7bef987dad2b1f47e97da9bdb936ee11e10ec7918b1abdb5d2080e57bee65513687aa498a9eb9aa92cd54b",
+        "dest-filename": "@babel-plugin-transform-new-target-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.0.1.tgz#2c0f2394cde4cd09147db054c68917e38f6d43a4",
+        "sha512": "efeea4f5cdff02e679739f7a2c9c7d9fddb703f8f79c5de8ae67b060117546b210be3be35ded7113c57c035285c85c176ef9ec853e85059157d24fc5d628277a",
+        "dest-filename": "postcss-modules-scope-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/svgo/-/svgo-1.1.1.tgz#12384b03335bcecd85cfa5f4e3375fed671cb985",
+        "sha512": "1819096e74ee1693388c56e21111c35a165cfd2fe4a474e8aa665a8376840633d82b8e0900dd90063beb188c4b3a80b23198ee15021f4ced9e25df2ec0b63ff6",
+        "dest-filename": "svgo-1.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835",
+        "sha512": "30587477f59aeef90a3b76372e569ca8011e1cad2672456acc389e50a4d3f8a1b18becc8a5e56c171ca6908891a5ba43ce21dcdbdd17afd0353b83a6ee8b6844",
+        "dest-filename": "neo-async-2.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e",
+        "sha512": "b7424a1a0aa4d967bef666b2dedd310dd9a779a5e6cb1ab4c6279870a1f122cac93bae27d4e88c58d52d7398102b53c0d0da5d091aed669e33f8851a2ae82b48",
+        "dest-filename": "@babel-plugin-syntax-object-rest-spread-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26",
+        "sha512": "02270fac00bb42ed49c4f099f59802665637e508059cda9cfb42ed6d13719d5c384d7be343bdb09ee2fd2507040605e423d24cf0cb13f64690a0772909124e60",
+        "dest-filename": "resolve-1.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz#6a957f105f37755e8645343d3038a22e1449cc4a",
+        "sha512": "604b5866bc371942ba7a64072ad865b4a359c2ccc17072b9f1881c8acfa0554ac5e3f1664d5af9082a903527e6be0db2f980c400dc98a1a2f3fd21ec9eeb02c1",
+        "dest-filename": "@babel-helper-call-delegate-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb",
+        "sha512": "e6d78eb105800571c70453fdcb7b244b93f777f59f597a6fdc5529cbe2e8accacd61a4fda48e282cc417ee3cd0d8a9253691a9587cdd0974c34f66375c695907",
+        "dest-filename": "anymatch-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss/-/postcss-7.0.11.tgz#f63c513b78026d66263bb2ca995bf02e3d1a697d",
+        "sha512": "f405dbfffe5472378e1287fd4fec8fc375d36b948bdb4ed93880bf94760fe266d44c4878334ac30107a442954034265dc10c0a841b456429378b787787685d5a",
+        "dest-filename": "postcss-7.0.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
+        "sha1": "3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
+        "dest-filename": "url-0.11.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa",
+        "sha1": "5eff8e3e684d569ae4cb2b1282604e8ba62149fa",
+        "dest-filename": "getpass-0.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df",
+        "sha512": "3266d02763131124e3b771a2ff7c86d701a920c8547dc232a54086b538b3151f4889c705c314a97e9d2fb4866590572512a1117a6c5f9d275910c47d56aa8415",
+        "dest-filename": "node-forge-0.7.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-4.2.0.tgz#def1f1ca5d6059d24a766e587942c21106ce1275",
+        "sha1": "def1f1ca5d6059d24a766e587942c21106ce1275",
+        "dest-filename": "dotenv-expand-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6",
+        "sha1": "137918d6d78283f7df7a6b7c5a63e140e69425e6",
+        "dest-filename": "component-emitter-1.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz#6b69628dfe4087798e0c4ed98e3d4a6b2fbd2f5f",
+        "sha512": "a8d491e23ae627c33554c33db626efc910075d0b363e66a4b1017b73508624d8a97dedc3f29fb080dc20b28fcfd80dabda6760056017963356474411640316f3",
+        "dest-filename": "@babel-helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43",
+        "sha1": "79a40644c362be82f26effe739c9bb5382046f43",
+        "dest-filename": "resolve-dir-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa",
+        "sha1": "2135d6dfa7a358c069ac9b178776288228450ffa",
+        "dest-filename": "pinkie-promise-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a",
+        "sha1": "a0b870729aae214005b7d5032ec2cbbb0fb4451a",
+        "dest-filename": "path-browserify-0.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80",
+        "sha1": "5c967ddd837a9bfdca5f2de84253abe8a1c03b80",
+        "dest-filename": "js-yaml-3.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02",
+        "sha512": "c0f56fff2fd043f5228ab8ffbe1de83fed56c3e0167a19a2d60e5f15618f17a22908108356b8601d132facb7dd61cc038774096c65c35b8240bb3c4494b4aa28",
+        "dest-filename": "invert-kv-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa",
+        "sha512": "7e3aae0b9f5c0fb0b25babab3572b4141b9f9197288861bcd304ee3ee8d7e7dd1c0794ed967db4136501e12fd601156a8577df665d8b3604be81074f2088a6fe",
+        "dest-filename": "extend-3.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.2.0.tgz#88f5fec3e7ad019014c97f7ee3c992f0adbf7fb8",
+        "sha512": "d4be6658b4af47be976144095e477f1044208eaf071d13fa950b994d3834540e2d4c63e919e9a609d01f408cf5af312e5809be79c3fc3f2c849b7d230b57900a",
+        "dest-filename": "@babel-plugin-proposal-object-rest-spread-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.2.2.tgz#18c816c70962640eab42fe8cae5f3947a5c65ccc",
+        "sha512": "238a3aef927f892f24f8fdfc76f2772011aa39b2d7c902d3c6dad1e2ef5c49424e511bda7de1166ffa4530e4f0b4dae6abbde6273c85eae7936ced41b4dd197a",
+        "dest-filename": "@babel-generator-7.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0",
+        "sha512": "eb0fb7b476ccf3b5a74969c434152f036a7124f2e14148392cac14407ab7afe5cf84833e1a1d91e7271bc0f0b2b866cd83e94f81d72741486e0b4da4242bdf7d",
+        "dest-filename": "worker-farm-1.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.0.tgz#1d4963a2fbffe58050aa9084ca20be81741c07de",
+        "sha512": "6617afdf9ff2ee144c7080ffba945e22f46c7be23d49587256b7bf29325225058ccf70b7f86f87a4eee6d702bfc9c904b6e8ca67b752e21915c409e61da20655",
+        "dest-filename": "sshpk-1.16.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz#a177271a8bca5019172f4f891fc6eed9cbf68d5d",
+        "sha512": "c582f400c649e20173250b0750a6b98e25968b6bc7efb595360ec9611c9ec308faa0f878c9bff2e98f590b0f5db23ffd51ab8c86dbb147ea2041dfff11d11534",
+        "dest-filename": "css-selector-tokenizer-0.7.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163",
+        "sha512": "8af22f869abf634b928dc1c370e21c7239988c62dc3f4f4c14613bcac030900be45dfa59942f7ce691f6fee8bae0329acdb4d6ff890ddf2aa8cd4c655f323a70",
+        "dest-filename": "eventemitter3-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64",
+        "sha512": "2f0672fa9dd216cd4fcad77f8d872de30a6fe3d1e2602a9df5195ce5955d93457ef18cefea34790659374d198f2f57edebd4f13f420c64627e58f154d81161c3",
+        "dest-filename": "pump-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a",
+        "sha1": "e524da09b4f66ff05df457546ec72ac99f13069a",
+        "dest-filename": "object.values-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf",
+        "sha512": "b50b4a03d588021045dfe54b02c7b232a65e0635b4007268c4eb58a92519349c5ab84ae62db566d855b5cbe27f600f5d52b002dfd2137a39595a1548c1ac242b",
+        "dest-filename": "readable-stream-2.3.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
+        "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
+        "dest-filename": "is-accessor-descriptor-0.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb",
+        "sha1": "72cb668b425228290abbfa856892587308a801fb",
+        "dest-filename": "meow-3.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url-loader/-/url-loader-1.1.2.tgz#b971d191b83af693c5e3fea4064be9e1f2d7f8d8",
+        "sha512": "7571e42a6c3c1613eabbc6ac4dcd69b817dedd37a1382a36f9198e39ebf9b2e34221805c4fadba931896835341564c1ce2b3bc0466bb80fef45bb557baa1eb8e",
+        "dest-filename": "url-loader-1.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a",
+        "sha1": "84c6e159b81904fdca59a0ef44cd870d31250f9a",
+        "dest-filename": "delegates-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.2.0.tgz#a3744fa03806cffe146dea4421a3e73bdcc47b1d",
+        "sha512": "67cdf95529c9278e82341b6d6a51c3fdd07e4a3d9ece663a5e9dfc9e9c14f3ba5e2ba9aa3b33a957c79892d7642d3124cf30fe26c4dcc5df38a3377c235e3eaf",
+        "dest-filename": "regexpu-core-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bluebird-lst/-/bluebird-lst-1.0.6.tgz#89bc4de0a357373605c8781f293f7b06d454f869",
+        "sha512": "081585a0fb943e972f314c5fcabf0329d239778923c45975877f7e55b2b13f72895891c4b0bb6e4f8a4f2e48e9c42194e80b24db5b6f6e77ed59776a23162575",
+        "dest-filename": "bluebird-lst-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
+        "sha512": "0e92a6d948bfc4deff1d0282b69671a11581859f59d24aadca01bc5c280d43c6650e7c6e4265a18f9eba8fc7cde02bb7fc999b86c0e8edf70026ae2cf61dbb13",
+        "dest-filename": "validate-npm-package-license-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9",
+        "sha1": "7cf4c54ef648e3813084c636dd2079e166c081d9",
+        "dest-filename": "readable-stream-1.1.14.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.2.3.tgz#948c8df4d4609c99c7e0130169f052ea6a7a8933",
+        "sha512": "02e1f35bb6bdadbbf95979af19a3d7ef0003c4591922a2a56c1875766654429e22c223e9904fd09eb8e2e920b8510090cef598fdca47113dbd7948574bd70b3f",
+        "dest-filename": "@babel-preset-env-7.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918",
+        "sha1": "5fc8686847ecd73499403319a6b0a3f3f6ae4918",
+        "dest-filename": "hash-base-3.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz#6e3d20fa6a3519f6b084ef9391ad58211efb0a1a",
+        "sha512": "ea5997453aeb663603f0d83cc51cafc9740961440a6125e126a5ce04bc36e2b7625ec1c03a5bf0e4f85eb2375c68c69d53fa723d0389e5d1eb78c8c1c709d02a",
+        "dest-filename": "@webassemblyjs-wasm-parser-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887",
+        "sha1": "41ae2eeb65efa62268aebfea83ac7d79299b0887",
+        "dest-filename": "etag-1.8.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/globals/-/globals-11.9.0.tgz#bde236808e987f290768a93d065060d78e6ab249",
+        "sha512": "e5c255b725d61fc3e224f54b673ce8222cd7c7de383b83a646ba393162b1e5f4f832070dece7da32eb4f79a4dd2420944706d676185c09670a21f7cf9e64f306",
+        "dest-filename": "globals-11.9.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe",
+        "sha1": "bcc6c49a42a2840ed997f323eada5ecd182e0bfe",
+        "dest-filename": "lodash.memoize-4.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457",
+        "sha512": "40690e41cf172fa06de4fc27b04c4a04fb8c281c671b15965b77d4e795ede1f787a3331485d50c6810a4dbdd2aa66ff01b9bbf4522b3c1d002e22e7562282284",
+        "dest-filename": "wide-align-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773",
+        "sha1": "d0225373aeb652adc1bc82e4945339a842754773",
+        "dest-filename": "lodash.uniq-4.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d",
+        "sha512": "6fab34e26dcefacdc21926ea0c8c8fe11e9a03001e62556af7e59459ea7a8876bc11345ff727a2d54e3c0b93267c9995f4088b61804a3ccabf5befd646942609",
+        "dest-filename": "import-local-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02",
+        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
+        "dest-filename": "read-pkg-up-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f",
+        "sha1": "e2689f8f356fad62cca65a3a91c5df5f9551692f",
+        "dest-filename": "extsprintf-1.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47",
+        "sha1": "e848396f057d223f24386924618e25694161ec47",
+        "dest-filename": "run-queue-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b",
+        "sha512": "3b6ee5e3168c62dfd1490e53477be9582001e4a6ff73321ca9414e33f0b87d870b9db6547353e48d300c8e87f6a4159a493c0e51deaa5077051951a3eda2309f",
+        "dest-filename": "snapdragon-node-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec",
+        "sha512": "085b074208ed5b550285d5e06f2246b679be3bfb8b41e65db5b0e8f267d48185c21d2335c20ad5c579ba6d2cab52e12b11bfb8b185460b3012051a2def3caba3",
+        "dest-filename": "buffer-alloc-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf",
+        "sha512": "6af3c46fc3fc1069f05ca0a5c2c35482bc958e595c46ab4c61ae3d353b1b41a818b93d437179e5d7dd79a315a3a321ab5d1eb31ff63465cf7ac56b0f7280ca78",
+        "dest-filename": "lcid-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
+        "sha1": "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
+        "dest-filename": "normalize-path-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de",
+        "sha512": "2a486de727ba6469b0bf8d2e503673b5ac93d9384b4067e78ff4fbd4dfd7cde65ea379dff1fa325bbcc64ec3d8904c9ade6e5fddc032a47faa7bb60eaccd54d9",
+        "dest-filename": "cipher-base-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-url-regex/-/css-url-regex-1.1.0.tgz#83834230cc9f74c457de59eebd1543feeb83b7ec",
+        "sha1": "83834230cc9f74c457de59eebd1543feeb83b7ec",
+        "dest-filename": "css-url-regex-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda",
+        "sha1": "5214c53a926d3552707527fbab415dbc08d06dda",
+        "dest-filename": "repeating-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441",
+        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
+        "dest-filename": "path-type-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef",
+        "sha512": "340a814ab8a318b65d33459936c2272c9a6426890bef65d88d4a670748b0b1183187b741e823ab1e74c137037413e9470c0273bbb90b0240de634f33dbf03486",
+        "dest-filename": "request-2.88.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42",
+        "sha512": "7daab066a9d6c5bc67f85d5ddfdf7281e6a640dcb794fa7f1fd1faacdaea621e054950ad718fb772e6f533103ca3d983779e6633c02086ebbf92ec9803a553b0",
+        "dest-filename": "camelcase-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a",
+        "sha1": "47e63f7af55afa6f92e1500e690eb8b8529c099a",
+        "dest-filename": "isstream-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274",
+        "sha512": "870d32c64f464ff1ebe722446271cd2985e4200f2654981df5d8ad61909ed7a65ccdc6842d861c7ef6977ac3400a4d8ef0ed274e23d07108465108fc24bcde7a",
+        "dest-filename": "set-value-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2",
+        "sha1": "0c7962a6adefa7bbd4ac366460a638552ae1a0a2",
+        "dest-filename": "strip-indent-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack/-/webpack-4.28.4.tgz#1ddae6c89887d7efb752adf0c3cd32b9b07eacd0",
+        "sha512": "3718c3eb55ac2bf6b72487705a3b48a629a6bc4e94ad18b7c86e78ffbe0793daf0363e453e40380c909fd73e01c8358b92f6614d913e3f70bf7a1e940f994373",
+        "dest-filename": "webpack-4.28.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c",
+        "sha512": "19298e4f611b1eb20d05ff5247b08310bc2527c004364dd09fb3a290ae2715802edceb5edbe258355be4a401109b7fd32cd109143ff16498f3cb183728158ecf",
+        "dest-filename": "path-parse-1.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020",
+        "sha512": "3c7c8cfac428baeef1b29410c042e51b0c1dd39997505ab01587ea3ced1c0bbc787f1c879e7b9eb6642be828c989a7c80e81f83288076fd74ea09cd1fd8e2b16",
+        "dest-filename": "xregexp-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499",
+        "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+        "dest-filename": "js-tokens-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "sha1": "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "dest-filename": "escape-string-regexp-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a",
+        "sha1": "2c637fe77c893afd2a663fe21aa9080068e2052a",
+        "dest-filename": "resolve-url-0.2.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777",
+        "sha1": "867ac74e3864187b1d3d47d996a78ec5c8830777",
+        "dest-filename": "typedarray-0.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce",
+        "sha512": "6a11aad199d5e66e57b592cc6febcfefa91c00ce6790baa4d25a6a02ea2348a1a042d9f87918b86591a6da8968db32851feb0cb166aa3825b576a0273abbbbda",
+        "dest-filename": "repeat-element-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d",
+        "sha512": "c1a9fc74c590d0651e17b0c610f5638477a6556fefcbac54626173458f1162a800d09b570bdac999b49c063a92bba760f6ad25c0f432e99026255af73cf4efa9",
+        "dest-filename": "css-what-2.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lightercollective/-/lightercollective-0.1.0.tgz#70df102c530dcb8d0ccabfe6175a8d00d5f61300",
+        "sha512": "27db60e6eada62840a6966e6af30c37b16c6ea11e731c592d6a2d880949613e9a903753938249e31485bf8ae79a2d819277e2815d474102bdd21bdf1b8ee4939",
+        "dest-filename": "lightercollective-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8",
+        "sha512": "dd681ed7484d713d4ababe0f0c5c0489e5d208c089b3fed6bd200272b318acda7e6fc9032f5ff4c09721e4d8b65abb7011ad883bc3ac55f78a21c88a083c7f40",
+        "dest-filename": "ssri-6.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "sha1": "72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "dest-filename": "pinkie-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-2.1.6.tgz#b6df18aa613b666e133f08adb5219c2684ac108d",
+        "sha1": "b6df18aa613b666e133f08adb5219c2684ac108d",
+        "dest-filename": "postcss-svgo-2.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e",
+        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
+        "dest-filename": "strip-bom-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df",
+        "sha512": "3bce103a7af489cb1b1462d2d0eddb23916cc31cd1afcfe01f05a40e5405b248523ebc905efad33318f118fe3e8966286ae2e806f7c3a64ace6ae67ed226690c",
+        "dest-filename": "wbuf-1.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz#4c5530313c08e1d5b3bbf3d2bbc747e278eea270",
+        "sha1": "4c5530313c08e1d5b3bbf3d2bbc747e278eea270",
+        "dest-filename": "postcss-merge-idents-2.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf",
+        "sha1": "bb43ff5598a6eb05d89b59fcd129c983313606bf",
+        "dest-filename": "strip-eof-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022",
+        "sha512": "c78ef54ac56352d051b5cbdde01cca13d9050beff64de5a0282830d1b65cc356fd9765f7417e6f096805f8a6996989bced2b3ffeb1e75abcaea43ae02ef99290",
+        "dest-filename": "mississippi-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f",
+        "sha512": "717f06daf47ff395181b9f45824a0c6a6c075089124a55776c1311b1bc555d5524da3e8d95e08a8d0fd613d79883d598e30db93bdc3cc0a3f8af335916651c52",
+        "dest-filename": "webpack-log-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+        "sha1": "b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+        "dest-filename": "unpipe-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab",
+        "sha512": "c6e3de2b839d8d6aad7e2e7dca5bd52f4627df9485df381c01cbfbac13c51d56846a9683af819d1a09b78fb7244f01fdc072fb7c69a07c09dbd3e4c7ac76fcb4",
+        "dest-filename": "write-file-atomic-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0",
+        "sha512": "40fe1e50cf3785af73998b696e7ca34cb006290ae2b40e575bf886f5c8edb8e23cb3546e2ffdd5e9adc37921df2aeb4943e6b251f79924f727098110cda3d0aa",
+        "dest-filename": "@babel-plugin-transform-shorthand-properties-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10",
+        "sha1": "f0241c45730a9fc6323b206dbf38edc741d0bb10",
+        "dest-filename": "console-browserify-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754",
+        "sha512": "778b337b524d0b8e7859da367e4bb2cc2afa68771b2fa3c61ae140cf42e2fcd70e9b5b421c69d60d19893fce5d87d221404ad3736b2f585117e711c83a8fff91",
+        "dest-filename": "handle-thing-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543",
+        "sha512": "3666fa4179042ecb81af6e02252922968e941c781b7a42b95226607c4e941c3dc46f6ed80baa03f9b85c4feb49e9c97c766b20750c675a572bcbc92c04804ba7",
+        "dest-filename": "extglob-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b",
+        "sha512": "8483f71043ecf2d07d013d4bf8d52ab70380a6ce269366686fcf4c5973078c75a0f668a517f8f8a2c9e740b5c108114193fb6f206fed51cf663942623c184f5c",
+        "dest-filename": "content-type-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f",
+        "sha512": "45e671bcd1c83aff3c1654fbaf17172080b47cfb78299a996ce962bf25ad5cbb7c112c7ce3377790c0ba88ae6355e4b6aadfa0edfb52ef27b87e2d3a5f9aed45",
+        "dest-filename": "aws4-1.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13",
+        "sha1": "b480c892e59a2f05954ce727bd3f2a4e882f9e13",
+        "dest-filename": "json-schema-0.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+        "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+        "dest-filename": "map-visit-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe",
+        "sha1": "540572d34f7ac3119f8f76c30cbc1b1e037affbe",
+        "dest-filename": "is-builtin-module-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f",
+        "sha512": "6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730",
+        "dest-filename": "debug-2.6.9.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e",
+        "sha512": "1f2a2a11be30affaeca1a2037d31f66952fd9d6b50a9b6b6fc7bccbfefbe9bcbb4773f34f0c69a80a20bc6d7de48ded053b9ef6d0efdce4def60e269f73b0d10",
+        "dest-filename": "needle-2.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz#f0aabb93d120a8ac61e925ea0ba440812dbe0e49",
+        "sha512": "b0ac67c877e2cf079380a65fed7b17bbf08dba92a1ce28e9b5f4ccf9ba33a2722ec95acb59552f6231366e1b9204c2fc55078cc6ae0c9badd0f6abdcbd471c89",
+        "dest-filename": "@babel-plugin-transform-dotall-regex-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-select/-/css-select-2.0.2.tgz#ab4386cec9e1f668855564b17c3733b43b2a5ede",
+        "sha512": "752a5868356859a10b8ef677992e8829933fcb63cc3dafd762811f60d65e3cbe14fd7832c5936ba0710745e0f1fddf9581787d55b093b45a8b9056e67aa79a45",
+        "dest-filename": "css-select-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65",
+        "sha1": "8b5bcbd9ec327c5041bf9ab023fd6750f1177e65",
+        "dest-filename": "fd-slicer-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491",
+        "sha1": "5517489b547091b0930e095654ced25ee97e9491",
+        "dest-filename": "is-regex-1.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389",
+        "sha1": "4daa4d9db00f9819880c79fa457ae5b09a1fd389",
+        "dest-filename": "emojis-list-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410",
+        "sha512": "d0259c08409d315736470dd4e70f598ea5fa81aeae6e4d710d52b1b4140f2bbc22b3fd05dabf53ea4e3274662179c97b614071055c612f9a22b0fb0dc403deda",
+        "dest-filename": "osenv-0.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614",
+        "sha1": "7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614",
+        "dest-filename": "interpret-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96",
+        "sha512": "de22fa0dbc29c8bce3477c4748534579bf4dcff33c583917df7b7518542714e9655a4f293ab87f2d2ac1e4e5e59e55b93fd2c7ef75fa9685bf7a881cf85e6526",
+        "dest-filename": "mime-types-2.1.21.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f",
+        "sha512": "17fd439d418fa29391662d278be0afac28074391721001d12d2029b9858c9ab6d2c28376327ffb93e1a5dfc8099d1ef2c83664e962d7c221a877524e58d0ca1b",
+        "dest-filename": "he-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014",
+        "sha1": "1dbd1c835658e35ce3f9984099db00585c782014",
+        "dest-filename": "autoprefixer-6.7.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46",
+        "sha512": "e6d2bb12dad9d0df8e2c532d86da8e8f87c8d8979bf3c0b808064fbb6e4b0d55205c9d00dc9b383cc1aaae7d095355b4321d7f67cc19cd83f1a94ad77816e809",
+        "dest-filename": "ci-info-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607",
+        "sha1": "f30f716c8e2bd346c7b67d3df3915566a7c05607",
+        "dest-filename": "indexes-of-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
+        "sha512": "c9726678d6b0dc39e728038a244e75b0bfd96987d6251975a4af5daf5f58142bb439b4b6df5001d7f2dba93291010e64c3c03dd2b03a7ebe2b88e5294d9bd064",
+        "dest-filename": "uuid-3.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176",
+        "sha1": "e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176",
+        "dest-filename": "pify-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16",
+        "sha1": "9aa20eb6aeebbff77fbd33e74ca01b33581d3a16",
+        "dest-filename": "is-date-object-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/thunky/-/thunky-1.0.3.tgz#f5df732453407b09191dae73e2a8cc73f381a826",
+        "sha512": "6304fca6398d7005c166aaee6eedb63f8158b21d83e1dc519a758138bf0993c6d471152d739df6ea4c77dadb939850c066d2ce18454d97c3ce011f23f3de88a3",
+        "dest-filename": "thunky-1.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903",
+        "sha1": "30057438eac6cf7f8c4767f38648d6697d75c903",
+        "dest-filename": "mkdirp-0.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426",
+        "sha512": "cfc1fcfdd8b293be81eeae7083e51dd3e0aacdc005de604123f6c0e677b9ceb454508bcd90963ffc3dc1ab21f9ef52ae002e0dafb470ec28d65f8af4cbd0ef36",
+        "dest-filename": "fsevents-1.2.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f",
+        "sha512": "bedbf91ed1a371852016b5dce8ac7be3b07cdcc451552e51d554c44285efb8ffa4308fa27fabb2c15d270c6a22c9d251cb8ca4ee1f687793a0d24c71e335179b",
+        "dest-filename": "configstore-3.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/core/-/core-7.2.2.tgz#07adba6dde27bb5ad8d8672f15fde3e08184a687",
+        "sha512": "e7dbc1d115add3d70072de4421ee7cf8dcc63f84c5483dc1cffff6fc42f2dd979378a17a5530f5017947f011866c25f43eea1b641b08cceec8008f4f1faede2b",
+        "dest-filename": "@babel-core-7.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.6.tgz#c8db9963ab4ce5b894222435482bd8ea854b7b5c",
+        "sha512": "09779d8ade86a484b3dec0b693616c1825293a152a29dc8bd25a8dac8990a236a09d43177fc85ec7803160546e32434672f257e500051b30795894264aff1289",
+        "dest-filename": "@babel-traverse-7.1.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz#b331e8e7cef8f8e2f007d42c3a36a0580a7d6ca7",
+        "sha512": "5f29e43b043289189d87418bb9aed291e1ef00f5d057f471b147844482e60089d97a002939400825f46e3d87b617b45c8ce0bdb56dc26fd8ee3ef002fec0aabe",
+        "dest-filename": "@webassemblyjs-wasm-opt-1.7.11.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400",
+        "sha1": "3a105ca17053af55d6e270c1f8288682e18da400",
+        "dest-filename": "verror-1.10.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0",
+        "sha1": "808adc2e79cf84738069b646cb20ec27beb629e0",
+        "dest-filename": "css-color-names-0.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/electron-webpack-js/-/electron-webpack-js-2.3.1.tgz#bdb234494ebf4d3ca0e8063c4b9a816a5bac5628",
+        "sha512": "448f95c3f2f0a8e40c186a5d926dac5adadd7ea8058575ee97e46431727e4fd2c986ddfc920f6aabd3ad0a27afac6432c5f729801f7d103af819c28c5454a118",
+        "dest-filename": "electron-webpack-js-2.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91",
+        "sha1": "99912d591836b5a6f5b345c0f07eefc08fc65d91",
+        "dest-filename": "assert-1.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9",
+        "sha1": "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9",
+        "dest-filename": "ip-regex-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz#470d4f9676d9fad50b324cdcce5fbabbc3da5787",
+        "sha512": "d09651776ca16b0a3bf51726e30d0bc123082c59855e3ba01b7caa7fe3ff52c2ac452d6624298cc309470e5320ec0bebf4baef4a9a7865250b3bdafc8e90b373",
+        "dest-filename": "@babel-helper-module-transforms-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+        "sha1": "9653a036fb7c1ee42342f2325cceefea3926c48d",
+        "dest-filename": "punycode-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede",
+        "sha1": "6f682b6a027a4e9ddfa4564cd2589d1d4e669ede",
+        "dest-filename": "num2fraction-1.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b",
+        "sha512": "afd4bf6725eefd7bbdab5b58969b0b22c6b711e2d75e4d15c25c6a4dc1517e0f4484c5bed7b91bb7d1b436b8029a119be6f4f687284964b7c31b1fbbfb9523ff",
+        "dest-filename": "y18n-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz#107405afcc4a190ec5ed450ecaa00ed0cafa7a4c",
+        "sha512": "b39346821084e22b529544bed16523f3c1ba71f3153261fc6e84cf36f0017fca1dfb67614fd583956bbc9f4d6b69000964c38af0287a8d27b16913bbb3077a6b",
+        "dest-filename": "regenerate-unicode-properties-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb",
+        "sha1": "bbb693b9ca915c232515b228b1a02b609043dbeb",
+        "dest-filename": "query-string-4.3.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz#23d90cd127b0a77994915332739034a1a4f3d658",
+        "sha1": "23d90cd127b0a77994915332739034a1a4f3d658",
+        "dest-filename": "postcss-merge-longhand-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766",
+        "sha512": "8a38ba93cece4976b409cacb97dcfe662612b91da8f9cd1b1ae3665ddae14d04da931cad005b02e7a480ac6628887949945a074a7be686971e649697915b8eb4",
+        "dest-filename": "nan-2.11.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed",
+        "sha1": "8869a0401253661c4c4ca3da6c2121ed555f5eed",
+        "dest-filename": "package-json-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677",
+        "sha512": "8793e98179168ad737f0104c61ac1360c5891c564956706ab85139ef11698c1f29245885ea067e6d4f96c88ff2a9788547999d2ec81835a3def2e6a8e94bfd3a",
+        "dest-filename": "is-plain-object-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+        "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+        "dest-filename": "posix-character-classes-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0",
+        "sha1": "4168133b42bb05c38a35b1ae4397c8298ab369e0",
+        "dest-filename": "env-paths-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.28.tgz#8e8968190d886c9477bc8d61e96f61af3f7ffa7f",
+        "sha512": "8e834d5b5802a77a851738f84adeb393e5a1fcd06fd2f33961b12b799934483e12db74bed7104a6fa70b0e0dae8f83f893f194325226e9c2880ea206faf76dd3",
+        "dest-filename": "css-tree-1.0.0-alpha.28.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b",
+        "sha512": "4cd3e37d3af8df6ab1ef23a34326979b7752474307f6f5e9ede4f50454a5fc2e7583e1059ce47d85383522b79a8460660cd09e86c72c85ee397fe0b54c165b2f",
+        "dest-filename": "boxen-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14",
+        "sha512": "0d8586934d650dcc5e4bf2bd2073c659f4fc3ec2666d746d45dd92c7bd939dbf29718650145d684836fc849b52d6f869db5daad51ce2e5d51ff7e9ead28f5422",
+        "dest-filename": "binary-extensions-1.12.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942",
+        "sha1": "2d10c06bdfd312ea9777695a4d28439456b75942",
+        "dest-filename": "normalize-range-0.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713",
+        "sha1": "279b225df1d582b1f54e65addd4352e18faa0713",
+        "dest-filename": "strict-uri-encode-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89",
+        "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
+        "dest-filename": "is-extendable-0.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8",
+        "sha512": "ffdd834d3a2b83826392d2cd2dee863d2dbf46f01dfd11abe8bba4b6659230b10e6baae39e5ac55cd8126d29a436f0a82f64f4dbc0346b525a24bcd13251681e",
+        "dest-filename": "url-parse-1.4.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2",
+        "sha1": "eb777df6011723a3b14e8a72c0805c8e86746bd2",
+        "dest-filename": "accepts-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25",
+        "sha1": "a7d0558bd89c42f795dd42328f740831ca53bc25",
+        "dest-filename": "color-name-1.1.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f",
+        "sha512": "6afa3e966fd099996fdbb66c8b4c44a2bd9f29ca961b9e83e5a7bd773925a48698edc40c2b937c552a5a3553cf6a08aa9b2ecbac48cad4859d18c3aa3eee5cb2",
+        "dest-filename": "@babel-helper-member-expression-to-functions-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205",
+        "sha1": "04a106672c18b085ab774d983dfa3ea138f22205",
+        "dest-filename": "chromium-pickle-js-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284",
+        "sha1": "a35008b20f41383eec1fb914f4cd5df79a264284",
+        "dest-filename": "minimist-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.13.6.tgz#128d1685a7c34d31ed17010fc87d6a12c1de6976",
+        "sha512": "e538773ac67881345dafd321a3cdc1436ddc7b1e2c461391e174c6fa6f9c25cd0586d5012bd567eb684127ea674189d2c683ceb0aa003cec7a15ca61c410bc9e",
+        "dest-filename": "@types-webpack-env-1.13.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4",
+        "sha512": "79354bac14adedf8db0f2833f34e69327b2d22cd954c1364466d2ac5977e33b0395c377155158ee4cc460576618d8e1ca8b60b76dac6a917fc9813e6cf04a959",
+        "dest-filename": "cross-spawn-6.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c",
+        "sha1": "ed141a6ac043a849ea588498e7dca8b15330e90c",
+        "dest-filename": "pify-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
+        "sha512": "27a4838d4803c508f936eb273ad745c43c0dffe1d6ca447c1842f072d27b99daa1732cb5c44738491147517bf14e9ebad586952808df44b67d702a92ead9f7d8",
+        "dest-filename": "regex-not-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.3.0.tgz#b0e2bac6beac39745f7db5c59d26a36a0b94f7dc",
+        "sha512": "1dc86f30935887d746482cbca4e4363bcbbf8685da2fed17867af01f44722e249730c4e5f56dcde8a514ef7f8914e8393c68edce5e95673510b27ae99bb4b36a",
+        "dest-filename": "global-modules-path-2.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51",
+        "sha512": "e02a0bfc0de17fdd15dd52048deba14af9461441caccecfe59f73621565cf85694814d1941a7c94cfe3d7ef9d42e2a4e3dc01faa1c88d9dbb04329eceb1aa360",
+        "dest-filename": "clap-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/csso/-/csso-3.5.1.tgz#7b9eb8be61628973c1b261e169d2f024008e758b",
+        "sha512": "beba942cb7df614d50dad2dd26f68261b38d4ad9df91f8a64715cd6868f1325748d02ec93c10b8ac1d51ca385f759e26d5fae6f2933db913ca1f777692767c82",
+        "dest-filename": "csso-3.5.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75",
+        "sha1": "c20b96d8c617748aaf1c16021760cd27fcb8cb75",
+        "dest-filename": "constants-browserify-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a",
+        "sha512": "f44d682e83967e14971c6bfa425c172629bbb8dcddf4456558afb6d6d094f49bbf911d3fa7601960fcf8a9272180ef0f94b207e05a5961fcf04beac492c66322",
+        "dest-filename": "readable-stream-3.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz#eec6c2a67b6c412a8db2042e77fe8da43f95c11d",
+        "sha1": "eec6c2a67b6c412a8db2042e77fe8da43f95c11d",
+        "dest-filename": "postcss-ordered-values-2.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26",
+        "sha512": "cfd9fbcadf6b3af209acc86f0ed0e272d2ab9051de8a190d97ab9632666598bead26d5fd0acfbcee82beb5e071f89220cef6d7df26474f7785f2fa5b0f11c95d",
+        "dest-filename": "chokidar-2.0.4.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7",
+        "sha1": "6c016adeac554f75823fe37ac05b92d5a4edb1f7",
+        "dest-filename": "regjsgen-0.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3",
+        "sha512": "71c6afff21afa1af340500e58c2c6c9a64375efc7ad3f5290488a3e50376d56df0062fe18480bd3a83be28ba6ef482534bd8f80d1549dda0c317d70c4a86b697",
+        "dest-filename": "base64-js-1.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4",
+        "sha512": "505302e197850b8f13a6f8fb0bc5202efb64694ba8bd05fee71356aec228306f28db3f9714a8ca68df625664bce1d3f054dd345b8c0f9aabd8a1917710602c7f",
+        "dest-filename": "@babel-highlight-7.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004",
+        "sha512": "452f51e91df93588109fef9f90359a3a6a86a23e0493d806b3e0cfc4d5192aec04d7cdf18c9ae82afca8d48cd515e5ef52bbe600bcba1560f9c6b7494f6e6032",
+        "dest-filename": "semver-5.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v4.0.1/electron-v4.0.1-linux-ia32.zip",
+        "sha256": "1594c5e7ea261ffc9456db4c0e1da374a0eda5dcedf4047e7cc91c3311a90e54",
+        "only-arches": [
+            "i386"
+        ],
+        "dest-filename": "electron-v4.0.1-linux-ia32.zip",
+        "dest": "flatpak-node/electron-cache"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v4.0.1/electron-v4.0.1-linux-x64.zip",
+        "sha256": "2d282fffb0de19a65b85f3b62be9abb1bd9fe1cf4bb2811e69fd153db4dfa18c",
+        "only-arches": [
+            "x86_64"
+        ],
+        "dest-filename": "electron-v4.0.1-linux-x64.zip",
+        "dest": "flatpak-node/electron-cache"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v4.0.1/electron-v4.0.1-linux-armv7l.zip",
+        "sha256": "66a42d2f0a83d2a3b94ef8467c40a97fe824bb7a81d7852a3a5eb339252fffdb",
+        "only-arches": [
+            "arm"
+        ],
+        "dest-filename": "electron-v4.0.1-linux-armv7l.zip",
+        "dest": "flatpak-node/electron-cache"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v4.0.1/electron-v4.0.1-linux-arm64.zip",
+        "sha256": "292f82cfcc12799137e77d284dcf4d97eb224a08ac5729593e3112f964e8aac3",
+        "only-arches": [
+            "aarch64"
+        ],
+        "dest-filename": "electron-v4.0.1-linux-arm64.zip",
+        "dest": "flatpak-node/electron-cache"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v4.0.1/SHASUMS256.txt",
+        "sha256": "ac21bbc6862f35c694a2ae7fefb405d62a44136469d029f8c4f2f8185eaae1f2",
+        "dest-filename": "SHASUMS256.txt-4.0.1",
+        "dest": "flatpak-node/electron-cache"
+    }
+]

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,3 +1,5 @@
+**NOTE:** For Node 10+, use [flatpak-node-generator](../flatpak-node-generator/README.md) instead.
+
 This is a tool to take npm5 `package-lock.json` lock files and generate flatpak-builder
 sources for this that let you build the npm-using app in flatpak-builder without
 network access.

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,0 +1,1 @@
+**NOTE:** For Node 10+, use [flatpak-node-generator](../flatpak-node-generator/README.md) instead.


### PR DESCRIPTION
While working on a Scratch Flatpak, several problems with the current flatpak-npm-generator and flatpak-yarn-generator became readily apparent (I'll explain more below). So to work around this, I created flatpak-node-generator, which combines support for both npm and yarn in a much cleaner and more powerful generator script.

I haven't done any documentation or examples yet, that should be coming soon. I just figured I'd submit this here for early review.

## Advantages

flatpak-node-generator has many features and advantages over the other two scripts:

- Supports newer Node and npm versions. At some point during Node 10's release cycle, npm started *caching the registry http requests*, which is what started the initial rabbit hole into creating this new script. flatpak-npm-generator did not handle this. It also generates a cache index like npm now wants.
- Works on newer Electron versions, flatpak-npm-generator relied on filenames that have changed around three years ago (!).
- Shared code, e.g. when I added support for Chromedriver, it immediately was applied to both npm and yarn generation.
- Related to the above, first-class support for modern Electron packaging workflows (e.g. via webpack).
- Due to the first point (needing to download each http requests), a linear, one by one download in the script generation would be brutally slow. Therefore, the new script is built on Python's asyncio system, which gives it pretty nice performance given it has to make a few thousand requests during a single script generation.
- Support for multiple package-lock.json and yarn.lock was broken with Git sources in the original npm-generator, this fixes that.
- The original regex replacements on Git sources would break if there were two on different commits, this also fixes that.
- The yarn parser is indentation-based, which means that it's overall more solid and won't break if a package name contains the word "dependencies".
- Automatically retries failed requests.
- Nicer architecture, e.g. when Yarn 2 comes out it will be easy to add a new lockfile parser while retaining the same offline download logic.
- This one is largely type-safe thanks to Python's new type annotations. 

## Disadvantages

- **aiohttp is required to get better performance.** flatpak-node-generator will fall back onto urllib.request if aiohttp is not found, but all requests will be linear, meaning the performance will be terrible.
- Python 3.6+ is required. It has been out for quite a while already, and based on current plans it will probably be EOL'd in a little over a year.
- There is no support for Electron 1 or Node 8. Node 8 is reaching EOL in just a few months, so this was pretty intentional. Anyone still on Node 8 can use flatpak-npm-generator; it will work since it was created before the new npm caching nightmare started.

For an example of why aiohttp is necessary for performance, generating the sources for Scratch's Flatpak took 1 minute and 17 seconds with aiohttp. Without it, it takes over *12 minutes*.