### PR TITLE
flatpak-pip-generator: fix regression caused by requirements support

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -131,13 +131,24 @@ for package in packages:
                 module['sources'].append(source)
         except subprocess.CalledProcessError:
             print("Failed to download {}".format(package))
-            print("Please fix the module manually in the generated file")           
+            print("Please fix the module manually in the generated file")
         modules.append(module)
 
 if opts.requirements_file:
-    output_filename = opts.output + '.json'
+    output_package = opts.output or 'pypi-dependencies'
 else:
-    output_filename = opts.output or package_name + '.json'
+    output_package = opts.output or package_name
+output_filename = output_package + '.json'
+
+if len(modules) == 1:
+    pypi_module = modules[0]
+else:
+    pypi_module = {
+        'name': output_package,
+        'buildsystem': 'simple',
+        'build-commands': [],
+        'modules': modules,
+    }
 
 with open(output_filename, 'w') as output:
-    output.write(json.dumps(modules, indent=4))
+    output.write(json.dumps(pypi_module, indent=4))


### PR DESCRIPTION
In my latest PR #59 that added requirements support, there was a regression caused by that which exported the module as a list.
Fixes #61