### PR TITLE
PIP: Prefer Generic Wheels over sdist

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -43,10 +43,16 @@ def get_pypi_url(name: str, filename: str) -> str:
 
 
 def get_package_name(filename: str) -> str:
-    segments = filename.split("-")
-    if len(segments) == 2:
-        return segments[0]
-    return "-".join(segments[:len(segments) - 1])
+    if filename.rsplit('.', 1)[1] == 'gz':
+        segments = filename.split("-")
+        if len(segments) == 2:
+            return segments[0]
+        return "-".join(segments[:len(segments) - 1])
+    elif filename.rsplit('-', 1)[1] == 'any.whl':
+        segments = filename.split("-")
+        if len(segments) == 5:
+            return segments[0]
+        return "-".join(segments[:len(segments) - 4])
 
 
 def get_file_hash(filename: str) -> str:
@@ -114,9 +120,21 @@ for package in packages:
             module['cleanup'] = ['/bin', '/share/man/man1']
 
         try:
-            subprocess.run(pip_download + [
-                '--no-binary', ':all:', package
-            ], check=True)
+            sdist_package = None
+            subprocess.run(pip_download + [package], check=True)
+            for filename in os.listdir(tempdir):
+                if filename.rsplit('.', 1)[1] != 'gz' and filename.rsplit('-', 1)[1] != 'any.whl':
+                    cwd = os.getcwd()
+                    os.chdir(tempdir)
+                    os.remove(filename)
+                    os.chdir(cwd)
+                    name = filename.split('-', 1)[0]
+                    sdist_package = name
+
+            if sdist_package:
+                subprocess.run(pip_download + [
+                    '--no-binary', ':all:', sdist_package
+                ], check=True)
             for filename in os.listdir(tempdir):
                 name = get_package_name(filename)
                 if name == 'setuptools':  # Already installed

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -43,17 +43,20 @@ def get_pypi_url(name: str, filename: str) -> str:
 
 
 def get_package_name(filename: str) -> str:
-    if filename.rsplit('.', 1)[1] == 'gz':
+    if filename.endswith('gz'):
         segments = filename.split("-")
         if len(segments) == 2:
             return segments[0]
         return "-".join(segments[:len(segments) - 1])
-    elif filename.rsplit('-', 1)[1] == 'any.whl':
+    elif filename.endswith('whl'):
         segments = filename.split("-")
         if len(segments) == 5:
             return segments[0]
         return "-".join(segments[:len(segments) - 4])
-
+    else:
+        raise Exception(
+            'Downloaded filename: {} does not end with gz or whl'.format(filename)
+        )
 
 def get_file_hash(filename: str) -> str:
     sha = hashlib.sha256()
@@ -120,21 +123,18 @@ for package in packages:
             module['cleanup'] = ['/bin', '/share/man/man1']
 
         try:
-            sdist_package = None
+            # May download the package twice, the first time it allows pip to
+            # select the preferred package, if the package downloaded is not
+            # platform generic, then it forces pip to download the sdist (using
+            # the --no-binary option).
             subprocess.run(pip_download + [package], check=True)
             for filename in os.listdir(tempdir):
-                if filename.rsplit('.', 1)[1] != 'gz' and filename.rsplit('-', 1)[1] != 'any.whl':
-                    cwd = os.getcwd()
-                    os.chdir(tempdir)
-                    os.remove(filename)
-                    os.chdir(cwd)
-                    name = filename.split('-', 1)[0]
-                    sdist_package = name
-
-            if sdist_package:
-                subprocess.run(pip_download + [
-                    '--no-binary', ':all:', sdist_package
-                ], check=True)
+                name = get_package_name(filename)
+                if not filename.endswith(('gz', 'any.whl')):
+                    os.remove(os.path.join(tempdir, filename))
+                    subprocess.run(pip_download + [
+                        '--no-binary', ':all:', name
+                    ], check=True)
             for filename in os.listdir(tempdir):
                 name = get_package_name(filename)
                 if name == 'setuptools':  # Already installed

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -30,7 +30,7 @@ opts = parser.parse_args()
 
 
 def get_pypi_url(name: str, filename: str) -> str:
-    url = 'https://pypi.python.org/pypi/{}/json'.format(name)
+    url = 'https://pypi.org/pypi/{}/json'.format(name)
     print('Extracting download url for', name)
     with urllib.request.urlopen(url) as response:
         body = json.loads(response.read().decode('utf-8'))

--- a/poetry/flatpak-poetry-generator.py
+++ b/poetry/flatpak-poetry-generator.py
@@ -23,7 +23,7 @@ def get_pypi_source(name: str, version: str, hashes: list) -> tuple:
     Returns (tuple): The url and sha256 hash.
 
     """
-    url = "https://pypi.python.org/pypi/{}/json".format(name)
+    url = "https://pypi.org/pypi/{}/json".format(name)
     print("Extracting download url and hash for {}, version {}".format(name, version))
     with urllib.request.urlopen(url) as response:
         body = json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
## Overview
This PR changes the pip builder tool to use the normal preferred pip download (wheel if available and sdist if there is no binary), and only force pip to use the sdist if pip downloads a platform specific wheel. 

## Issue

In order to install an app using Poetry, I have to `pip install poetry`. Some of the Poetry dependencies like tomlkit require Poetry to build their sdist. So I get trapped in a catch-22, which can only be fixed by the FlatHub servers having Poetry (like setuptools), or we need to use the binary distributions that are available.

Use of a generic wheels should actually be preferred when they are available, since they offer:

- Faster installation for pure python packages
- Avoids arbitrary code execution for installation. (Avoids setup.py)
- Allows better caching for testing and continuous integration.
- Creates .pyc files as part of installation to ensure they match the python interpreter used.
- More consistent installs across platforms and machines.

My understanding why the pip flatpak-builder-tools don't use wheels is because generic wheels aren't available for all packages, and pip only allows options to set the platform to any (generic) if you force binary install using the `--binary-only :all:` option. This will then error out for any packages that don't have wheels.

## Solution

Updates the pip builder tool to conduct the following for each package:
1. Run a normal `pip download package`
2. Check for a platform specific wheel (the filename extension is not `all.whl` or `gz`)
3. If it is platform specific, delete the file and redownload the package, this time forcing `--no-binary`

I also updated the url for PyPI from pypi.python.org to pypi.org.