### PR TITLE
Poetry: Remove optional dependencies from generated sources

### DIFF
--- a/poetry/flatpak-poetry-generator.py
+++ b/poetry/flatpak-poetry-generator.py
@@ -65,7 +65,9 @@ def get_module_sources(parsed_lockfile: dict, include_devel: bool = True) -> lis
                 if (
                     package["category"] == "dev"
                     and include_devel
+                    and not package["optional"]
                     or package["category"] == "main"
+                    and not package["optional"]
                 ):
                     hashes = all_hashes[package["name"]]
                     url, hash = get_pypi_source(
@@ -93,7 +95,9 @@ def get_dep_names(parsed_lockfile: dict, include_devel: bool = True) -> list:
                 if (
                     package["category"] == "dev"
                     and include_devel
+                    and not package["optional"]
                     or package["category"] == "main"
+                    and not package["optional"]
                 ):
                     dep_names.append(package["name"])
     return dep_names


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

# Overview
Poetry allows optional dependencies to be defined. For example, you can define an optional group of dependencies in your `pyproject.toml` that are needed to build project docs.

# Current Behavior
The current behavior of the poetry builder tool is that it pulls in all optional dependencies.

# Updated Behavior
Since optional dependencies shouldn't be needed to build an application, this PR excludes these dependencies.