### PR TITLE
go: detect git directory for dependencies

### DIFF
--- a/go-get/flatpak-go-get-generator.py
+++ b/go-get/flatpak-go-get-generator.py
@@ -26,6 +26,10 @@ import subprocess
 import argparse
 import json
 
+def is_git_repository(p):
+    is_git_repo = p.is_dir() and (p / ".git").is_dir()
+    return is_git_repo
+
 def repo_paths(build_dir: Path) -> List[Path]:
     src_dir = build_dir / 'src'
     repo_paths: List[Path] = []
@@ -34,8 +38,13 @@ def repo_paths(build_dir: Path) -> List[Path]:
     for domain in domains:
         domain_users = domain.iterdir()
         for user in domain_users:
-            user_repos = user.iterdir()
-            repo_paths += list(user_repos)
+            if is_git_repository(user):
+                repo_paths.append(user)
+            else:
+                user_repos = user.iterdir()
+                for ur in user_repos:
+                    if is_git_repository(ur):
+                        repo_paths.append(ur)
     return repo_paths
 
 def repo_source(repo_path: Path) -> Dict[str, str]:

--- a/go-get/flatpak-go-get-generator.py
+++ b/go-get/flatpak-go-get-generator.py
@@ -40,10 +40,15 @@ def repo_paths(build_dir: Path) -> List[Path]:
 
 def repo_source(repo_path: Path) -> Dict[str, str]:
     def current_commit(repo_path: Path) -> str:
-        return subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, cwd=repo_path, text=True).stdout.strip()
+        output = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
+            cwd=repo_path).decode('ascii').strip()
+        return output
 
     def remote_url(repo_path: Path) -> str:
-        return subprocess.run(['git', 'remote', 'get-url', 'origin'], capture_output=True, cwd=repo_path, text=True).stdout.strip()
+        output = subprocess.check_output(
+            ['git', 'remote', 'get-url', 'origin'],
+            cwd=repo_path).decode('ascii').strip()
+        return output
     
     repo_path_str = str(repo_path)
     dest_path = repo_path_str[repo_path_str.rfind('src/'):]


### PR DESCRIPTION
This PR has two commits: One for making the code compatible with Python < 3.7 and the other for detecting dependencies more properly.  I don't know how "go get" behaves, so I have no clue what the correct fix here is, but it seems to make it work a little better than before. It's confident that it's not worse than before.

CCing @cagatay-y 