### PR TITLE
pip: fix incorrect package version when downloading platform generic packages

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -133,11 +133,10 @@ for package in packages:
             # the --no-binary option).
             subprocess.run(pip_download + [package], check=True)
             for filename in os.listdir(tempdir):
-                name = get_package_name(filename)
                 if not filename.endswith(('gz', 'any.whl')):
                     os.remove(os.path.join(tempdir, filename))
                     subprocess.run(pip_download + [
-                        '--no-binary', ':all:', name
+                        '--no-binary', ':all:', package
                     ], check=True)
             for filename in os.listdir(tempdir):
                 name = get_package_name(filename)


### PR DESCRIPTION
When downloading a platform generic package, we need to make sure that we download the correct package version (when specified in the requirements file).

The `get_package_name()` function returns only the package name. Downloading a package only by its name results in downloading the latest version (which would create a conflict).