### PR TITLE
pip: add link to requirements.txt documentation

### DIFF
--- a/pip/readme.md
+++ b/pip/readme.md
@@ -17,7 +17,7 @@ Tool to automatically generate `flatpak-builder` manifest json from a `pip` pack
 
 You can also list multiple packages in single command.
 
-If your project contains a requirements.txt with all the project dependencies, you can use 
+If your project contains a [requirements.txt file](https://pip.readthedocs.io/en/stable/user_guide/#requirements-files) with all the project dependencies, you can use 
 ```
 flatpak-pip-generator --requirements-file=/the/path/to/requirements.txt --output pypi-dependencies
 ```


### PR DESCRIPTION
On IRC, after reading this documentation, someone asked for a
“requirements.txt file example?”, not realising this just refers to the
de-facto standard used by many Python projects. Add a link to clarify
this.