### PR TITLE
pip: use --prefix also for python2 pip

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -85,10 +85,8 @@ else:
 
 if opts.python2:
     pip_executable = 'pip2'
-    pip_install_prefix = '--install-option="--prefix=${FLATPAK_DEST}"'
 else:
     pip_executable = 'pip3'
-    pip_install_prefix = '--prefix=${FLATPAK_DEST}'
 
 modules = []
 
@@ -109,7 +107,7 @@ for package in packages:
             'install',
             '--no-index',
             '--find-links="file://${PWD}"',
-            pip_install_prefix,
+            '--prefix=${FLATPAK_DEST}',
             shlex.quote(package)
         ]
         if opts.no_build_isolation:


### PR DESCRIPTION
When I needed to use python2-pip in the guest, it refused to use wheels,
because --install-option is used. The Internet suggests, that --prefix
can be used, regardless.
It works for me™.

https://github.com/flatpak/flatpak-builder-tools/commit/74ccb11d19d6fd55bf530063dcec6833a5fb5ef3 seems to have introduced the `--install-options` flag which refers to an old pip version found in the 1.6 SDK. These times are probably over.

CCing @danyeaw as a recent committer of this file and @barthalion as the author of the commit mentioned above.