### PR TITLE
cargo: centrally replace git+ urls and bare clone in to git/db

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -100,7 +100,7 @@ def generate_sources(cargo_lock):
                     {
                         "type": "shell",
                         "commands": [
-                            f"git clone --bare {CARGO_CRATES}/{name}  {CARGO_GIT_DB}/{name}-{hash}"
+                            f"git clone --bare {CARGO_CRATES}/{name} {CARGO_GIT_DB}/{name}-{hash}"
                         ]
                     },
                     {


### PR DESCRIPTION
Hm. It's unfortunate that we make this change, but it seems to work much
better on gst-plugin-cdt.

The upstream cargo command explicitly checks for the presence of
"github.com" in the URL to then replace the protocol with "https".
We now additionally replace "git+https://" with "https://".
Initially, I tried to only replace when writing out the flatpak
manifest. But then I noticed how "cargo vendor" prints out the
"https://" URL (when telling you how to configure your cargo,
rather than "git+https", so something seems to have replaced the
prefix there.
We try to do the same.

Another change is the cloning of the bare repository into "git/db".
It seems cargo somehow and sometimes expects repositories to be there.
A "strace -e statx  cargo build" helped to reveal that it was looking for the
directory.  Since flatpak-builder can't bare-clone a git repository, we do it
ourselves.