### PR TITLE
flatpak-cargo-generator: Fixed handling of URLs ending with .git

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -53,7 +53,7 @@ def canonical_url(url):
         u = u._replace(path = u.path.lower())
 
     if u.path.endswith(".git"):
-        u.path = u.path[:-len(".git")]
+        u = u._replace(path = u.path[:-len(".git")])
 
     return u
 


### PR DESCRIPTION
Fix `flatpak-cargo-generator.py` canoniclizing URLs ending in ".git".

E.g. trying `flatpak-cargo-generator.py` on the `Cargo.lock` from https://github.com/ImageOptim/gifski/ failed without this patch.