### PR TITLE
Fix unintended ARRAY reference error

### DIFF
--- a/cpan/flatpak-cpan-generator.pl
+++ b/cpan/flatpak-cpan-generator.pl
@@ -74,7 +74,7 @@ sub get_source_for_dep {
     ],
   });
 
-  die "Unexpected @{[$release_set->total]} releases for $dep->{name}@$dep->{version}"
+  die "Unexpected @{[$release_set->total]} releases for $dep->{name}\@$dep->{version}"
     if $release_set->total != 1;
   my $release = $release_set->next;
 


### PR DESCRIPTION
The @ sign is meant literally here, so escape it.

In the original form the code will end with a fairly obscure error message

```
Not an ARRAY reference at ./flatpak-cpan-generator.pl line 77.
```

With the fix, the error message is printed as intended. Below for example is the error when printed when trying to generate flatpak cpan rules for Date::Parse:

```
Unexpected 0 releases for Date::Parse@2.31 at ./flatpak-cpan-generator.pl line 81.
```

Note: the reason the script fails on this module is because there is something odd going one with the `Date::Parse` module in cpan. If you try to install it, it will install the `TimeDate` module instead. I haven't figured out why yet or how the flatpak-cpan-generator script can be adjusted to deal with it.

This PR at least clarifies the error message.