### PR TITLE
Proposed improvements to the cpan sources generator

### DIFF
--- a/cpan/README.md
+++ b/cpan/README.md
@@ -9,7 +9,7 @@ Generates a sources file for a list of CPAN modules.
 - JSON::MaybeXS
 - LWP::UserAgent
 - MetaCPAN::Client
-- Pod::Simple::SimpleTree
+- Capture::Tiny
 
 Example installation on Fedora:
 
@@ -116,7 +116,7 @@ flatpak-cpan-generator works by:
 
 - Using cpanminus to install all the needed libraries into a separate directory. cpanminus is
   used over vanilla CPAN because the latter does not seem to support this use case at all.
-- Parsing perllocal.pod in order to extract the names and versions of the installed packages.
+- Parsing the output of cpanm in order to extract the names and versions of the installed packages.
 - Querying CPAN to grab the distribution URLs for each and saving them into the sources file.
 
 We can't just resolve the dependency list without cpanminus, because many CPAN packages don't

--- a/cpan/README.md
+++ b/cpan/README.md
@@ -30,9 +30,10 @@ This will write a generated-sources.json (the filename can be changed via `-o/--
 - Downloads the dependencies into a directory named `perl-libs`. (You can change the directory
   name via `-d/--dir`.)
 - Saves a file `install.sh` into the same directory as above that installs all the dependencies
-  by running `perl Makefile.PL && make install` inside each directory.
+  by running `perl Makefile.PL && make install` or `perl Build.PL && ./Build && ./Build install`
+  inside each directory.
 
-In addition, both Perl itself and modules installed via Makefile.PL tend to not have write
+Note both Perl itself and modules installed via Makefile.PL tend to not have write
 permission on shared objects they installed, which can break flatpak-builder. The example
 below shows how to work around that via chmod.
 

--- a/cpan/flatpak-cpan-generator.pl
+++ b/cpan/flatpak-cpan-generator.pl
@@ -115,7 +115,20 @@ sub main {
     type => 'script',
     'dest-filename' => "@{[$opts->dir]}/install.sh",
     commands => [
-      map { "cd $_->{dest} && perl Makefile.PL && make install && cd ../.." } @sources
+      "set -e",
+      "function make_install {",
+      "    mod_dir=\$1",
+      "    cd \$mod_dir",
+      "    if [ -f 'Makefile.PL' ]; then",
+      "        perl Makefile.PL && make install",
+      "    elif [ -f 'Build.PL' ]; then",
+      "        perl Build.PL && ./Build && ./Build install",
+      "    else",
+      "        echo 'No Makefile.PL or Build.PL found. Do not know how to install this module'",
+      "        exit 1",
+      "    fi",
+      "}",
+      map { "(make_install $_->{dest})" } @sources
     ],
   };
 


### PR DESCRIPTION
I have been experimenting with the cpan sources generator for the GnuCash flatpak. GnuCash can optionally use the `Finance::Quote` perl module so it would be nice to be able to ship it in the flatpak as well.

I ran into several issues while using the script:
1. Some modules have failing unit tests, causing the generation script to end prematurely. I currently seeing this with `HTML::TableExtract-2.15`
2. Some of the modules installed with `cpanm` failed to appear in the list of sources. I found two possible causes:
   1. The particular module doesn't write anything to `perllocal.pod`. This is the case for example with `HTML::Tree`. These missing modules go unnoticed until the final flatpak tries to use them.
   1. The module name written to `perllocal.pod` can't be mapped back to the module's distribution name. This happened to me with the `Date::Parse` module. It's distribution name is `TimeDate`. The generator script aborts on this one with
```
Unexpected 0 releases for Date::Parse@2.31 at ./flatpak-cpan-generator.pl line 81.
```
3. Some modules don't have a `Makefile.PL` so the command generated to install them fails.

This PR proposes the following fixes:
1. Run cpanm with the `-n` flag to skip unit tests.
2. Parse the output of the `cpanm` run rather than `perllocal.pod`. This output dutifully lists the formal module name for each module that was installed successfully. With a bit of regex parsing these names can be passed directly to the MetaCPAN query to find the proper distribution names.
3.  All of the modules without `Makefile.PL` I encountered in the `Finance::Quote` dependencies turn out to have a `Build.PL` file instead which can also be used to build and install the module. So this PR refines the generated `install.sh` script to do the right thing with either a `Makefile.PL` or a `Build.PL` file.