### PR TITLE
node: make it work with git+https urls

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -508,12 +508,12 @@ class NpmLockfileProvider(LockfileProvider):
 
     def parse_git_source(self, version: str, from_: str) -> Optional[GitSource]:
         git_prefixes = {
-            'github': 'https://github.com/',
-            'gitlab': 'https://gitlab.com/',
-            'bitbucket': 'https://bitbucket.com/',
-            'git': 'git://',
-            'git+http': 'http://',
-            'git+https': 'https://',
+            'github:': 'https://github.com/',
+            'gitlab:': 'https://gitlab.com/',
+            'bitbucket:': 'https://bitbucket.com/',
+            'git:': 'git://',
+            'git+http:': 'http:',
+            'git+https:': 'https:',
         }
 
         assert version.count('#') == 1, version
@@ -522,7 +522,7 @@ class NpmLockfileProvider(LockfileProvider):
         url: Optional[str] = None
 
         for npm_prefix, url_prefix in git_prefixes.items():
-            if original.startswith(npm_prefix + ':'):
+            if original.startswith(npm_prefix):
                 url = url_prefix + original[len(npm_prefix)+1:]
                 break
         else:


### PR DESCRIPTION
The generator produced wrongly looking URLs for git+https:// URLs:

Initialized empty Git repository in
/srv/buildbot/sources/git/https_github.com_Simon-Laux_parcel-plugin-clean-dist.git-JT0KG0/
fatal: unable to access
'https:////github.com/Simon-Laux/parcel-plugin-clean-dist.git/': Could
not resolve host: https; Unknown error
Failed to download sources: module delta: Child process exited with code
128

Notice how there are too many slashes.

Do also note how the behaviour should change now. The code suggests that
a URL starting with "git+https:" is going to be replaced with
"https://". This change changes this behaviour and strips the slashes
from the replacement. I hope that doesn't break any other users.

https://flathub.org/builds/#/builders/27/builds/15301


This could fix https://github.com/flatpak/flatpak-builder-tools/issues/64
