### PR TITLE
Add DUB generator

### DIFF
--- a/dub/flatpak-dub-generator.py
+++ b/dub/flatpak-dub-generator.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+__license__ = 'MIT'
+import json
+import urllib.request
+import urllib.parse
+import hashlib
+import logging
+import argparse
+
+REGISTRY_URL = "https://code.dlang.org/"
+
+def get_remote_sha256(url):
+    logging.info(f"Calculating sha256 of {url}")
+    response = urllib.request.urlopen(url)
+    sha256 = hashlib.sha256()
+    while True:
+        data = response.read(4096)
+        if not data:
+            break
+        sha256.update(data)
+    return sha256.hexdigest()
+
+def load_dub_selections(dub_selections_file="dub.selections.json"):
+    with open(dub_selections_file, "r") as f:
+        return json.load(f)
+
+def generate_sources(dub_selections):
+    sources = []
+    local_packages = []
+
+    for name, version in dub_selections["versions"].items():
+        dl_url = urllib.parse.urljoin(REGISTRY_URL, f"/packages/{name}/{version}.zip")
+        sources += [{
+            "type": "archive",
+            "url": dl_url,
+            "sha256": get_remote_sha256(dl_url),
+            "dest": f".flatpak-dub/{name}-{version}"
+        }]
+        local_packages += [{
+            "name": name,
+            "version": version,
+            "path": f"@builddir@/.flatpak-dub/{name}-{version}"
+        }]
+    sources += [
+        {
+            "type": "file",
+            "url": "data:" + urllib.parse.quote(json.dumps(local_packages)),
+            "dest": ".dub/packages",
+            "dest-filename": "local-packages.json"
+        },
+        {
+            "type": "shell",
+            "commands": [
+                "sed \"s|@builddir@|$(pwd)|g\" -i .dub/packages/local-packages.json"
+            ]
+        }
+    ]
+
+    return sources
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('dub_selections_file', help='Path to the dub.selections.json file')
+    parser.add_argument('-o', '--output', required=False, help='Where to write generated sources')
+    args = parser.parse_args()
+    if args.output is not None:
+        outfile = args.output
+    else:
+        outfile = 'generated-sources.json'
+
+    generated_sources = generate_sources(load_dub_selections(args.dub_selections_file))
+    with open(outfile, 'w') as out:
+        json.dump(generated_sources, out, indent=4, sort_keys=False)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    main()

--- a/dub/flatpak-dub-generator.py
+++ b/dub/flatpak-dub-generator.py
@@ -23,7 +23,9 @@ def get_remote_sha256(url):
 
 def load_dub_selections(dub_selections_file="dub.selections.json"):
     with open(dub_selections_file, "r") as f:
-        return json.load(f)
+        dub_selections = json.load(f)
+    assert dub_selections.get("fileVersion") == 1
+    return dub_selections
 
 def generate_sources(dub_selections):
     sources = []

--- a/dub/flatpak-dub-generator.py
+++ b/dub/flatpak-dub-generator.py
@@ -29,10 +29,14 @@ def generate_sources(dub_selections):
     sources = []
     local_packages = []
 
-    for name, version in dub_selections["versions"].items():
-        if isinstance(version, dict) and "path" in version:
-            logging.warning(f"Skipping path based dependency {name}")
-            continue
+    for name, version_obj in dub_selections["versions"].items():
+        if isinstance(version_obj, dict):
+            if "path" in version_obj:
+                logging.warning(f"Skipping path based dependency {name}")
+                continue
+            version = version_obj["version"]
+        else:
+            version = version_obj
         dl_url = urllib.parse.urljoin(REGISTRY_URL, f"/packages/{name}/{version}.zip")
         sources += [{
             "type": "archive",

--- a/dub/flatpak-dub-generator.py
+++ b/dub/flatpak-dub-generator.py
@@ -30,6 +30,9 @@ def generate_sources(dub_selections):
     local_packages = []
 
     for name, version in dub_selections["versions"].items():
+        if isinstance(version, dict) and "path" in version:
+            logging.warning(f"Skipping path based dependency {name}")
+            continue
         dl_url = urllib.parse.urljoin(REGISTRY_URL, f"/packages/{name}/{version}.zip")
         sources += [{
             "type": "archive",


### PR DESCRIPTION
DUB is the package manager for D lang. This generator should supplement recently added to Flathub `ldc` and `dmd` SDK extensions.
I've never used  DUB before, so maybe did something sub-optimal here.
Adding `generated-sources.json` to the manifest should be enough for this to work.
CC @Cogitri