### PR TITLE
node: Option to download ffmpeg archive

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -189,11 +189,14 @@ things to note:
 
 Both of these cases are handled by the electron-webpack-quick-start example.
 
-### Non-patented ffmpeg
+### ffmpeg support
+
+If your app needs separate ffmpeg archive, add `--electron-ffmpeg=archive` option
+to flatpak-node-generator.
 
 By defualt, the ffmpeg that Electron ships with has proprietary codecs built in
 like AAC and H.264. If you don't need these, you can pass
-`--electron-non-patented-ffmpeg` to flatpak-node-generator. This will download
+`--electron-ffmpeg=lib` to flatpak-node-generator. This will download
 a patent-clean ffmpeg binary to `flatpak-node/libffmpeg.so`, which you can then
 use to overwrite the default Electron ffmpeg, e.g.:
 

--- a/node/README.md
+++ b/node/README.md
@@ -191,8 +191,9 @@ Both of these cases are handled by the electron-webpack-quick-start example.
 
 ### ffmpeg support
 
-If your app needs separate ffmpeg archive, add `--electron-ffmpeg=archive` option
-to flatpak-node-generator.
+If your app needs separate ffmpeg for matching electron version, add
+`--electron-ffmpeg=archive` option to flatpak-node-generator. This will put
+`ffmpeg-$suffix.zip` alongside electron in the cache directory.
 
 By defualt, the ffmpeg that Electron ships with has proprietary codecs built in
 like AAC and H.264. If you don't need these, you can pass

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -439,11 +439,11 @@ class SpecialSourceProvider:
         if self.electron_ffmpeg is not None:
             for binary in manager.find_binaries('ffmpeg'):
                 assert binary.arch is not None
-                if self.electron_ffmpeg == "lib":
+                if self.electron_ffmpeg == 'lib':
                     self.gen.add_archive_source(binary.url, binary.integrity,
                                                 destination=self.gen.data_root,
                                                 only_arches=[binary.arch.flatpak])
-                elif self.electron_ffmpeg == "archive":
+                elif self.electron_ffmpeg == 'archive':
                     self.gen.add_url_source(binary.url, binary.integrity,
                                             destination=electron_cache_dir / binary.filename,
                                             only_arches=[binary.arch.flatpak])
@@ -1000,7 +1000,7 @@ async def main() -> None:
     parser.add_argument('--electron-chromedriver',
                         help='Use the ChromeDriver version associated with the given '
                              'Electron version')
-    parser.add_argument('--electron-ffmpeg', choices=["archive", "lib"],
+    parser.add_argument('--electron-ffmpeg', choices=['archive', 'lib'],
                         help='Download the ffmpeg binaries')
     # Internal option, useful for testing.
     parser.add_argument('--stub-requests', action='store_true', help=argparse.SUPPRESS)


### PR DESCRIPTION
Some apps require electron-ffmpeg archive to be present alongside electron archive, so that cache layout would look like this:
```
flatpak-node/electron-cache
├── electron-v4.2.12-linux-x64.zip
├── ffmpeg-v4.2.12-linux-x64.zip
└── SHASUMS256.txt-4.2.12
```
This removes `--electron-non-patented-ffmpeg` option and adds `--electron-ffmpeg=` option with two possible values - `lib` and `archive`. The former will do the same that `--electron-non-patented-ffmpeg` currently does, while the later will instead add a file source with ffmpeg archive and place it alongside electron.