### PR TITLE
cargo: Small fix for git packages support

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -47,15 +47,14 @@ def get_git_cargo_packages(git_url, commit):
         subprocess.run(['git', 'clone', git_url, tmdir], check=True)
     subprocess.run(['git', 'checkout', commit], cwd=tmdir, check=True)
     root_toml = load_toml(os.path.join(tmdir, 'Cargo.toml'))
+    assert 'package' in root_toml or 'workspace' in root_toml
     packages = {}
     if 'package' in root_toml:
         packages[root_toml['package']['name']] = '.'
-    elif 'workspace' in root_toml:
+    if 'workspace' in root_toml:
         for subpkg in root_toml['workspace']['members']:
             pkg_toml = load_toml(os.path.join(tmdir, subpkg, 'Cargo.toml'))
             packages[pkg_toml['package']['name']] = subpkg
-    else:
-        raise ValueError(f'Neither "package" nor "workspace" in {git_url}')
     return packages
 
 def get_git_sources(package):


### PR DESCRIPTION
Follow-up for #108 
It appears that `Cargo.toml` in git repo can contain both a `package` _and_ `workspace`.