### PR TITLE
Many, many node improvements

### DIFF
--- a/node/.style.yapf
+++ b/node/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+based_on_style = pep8
+column_limit = 90
+indent_dictionary_value = true

--- a/node/README.md
+++ b/node/README.md
@@ -29,7 +29,8 @@ get npm with electron-builder.
 ```
 usage: flatpak-node-generator.py [-h] [-o OUTPUT] [-r] [-R RECURSIVE_PATTERN]
                                  [--registry REGISTRY] [--no-devel]
-                                 [--no-aiohttp] [--retries RETRIES] [-P] [-s]
+                                 [--no-aiohttp] [--no-requests-cache]
+                                 [--retries RETRIES] [-P] [-s]
                                  [--node-chromedriver-from-electron NODE_CHROMEDRIVER_FROM_ELECTRON]
                                  [--electron-ffmpeg {archive,lib}]
                                  [--electron-node-headers]
@@ -54,6 +55,7 @@ optional arguments:
   --no-devel            Don't include devel dependencies (npm only)
   --no-aiohttp          Don't use aiohttp, and silence any warnings related to
                         it
+  --no-requests-cache   Disable the requests cache
   --retries RETRIES     Number of retries of failed requests
   -P, --no-autopatch    Don't automatically patch Git sources from
                         package*.json
@@ -73,6 +75,12 @@ containing all the sources set up like needed for the given package manager.
 
 If you're on npm and you don't want to include devel dependencies, pass --no-devel, and pass
 --production to `npm install` itself when you call.
+
+### Caching
+
+flatpak-node-generator will cache many API responses and archives from the server to speed up
+subsequent runs. You can disable this using `--no-requests-cache`, and it can be cleared via
+`rm -rf ${XDG_CACHE_HOME:-$HOME/.cache}/flatpak-node-generator`.
 
 ### Splitting mode
 

--- a/node/README.md
+++ b/node/README.md
@@ -30,8 +30,9 @@ get npm with electron-builder.
 usage: flatpak-node-generator.py [-h] [-o OUTPUT] [-r] [-R RECURSIVE_PATTERN]
                                  [--registry REGISTRY] [--no-devel]
                                  [--no-aiohttp] [--retries RETRIES] [-P] [-s]
-                                 [--electron-chromedriver ELECTRON_CHROMEDRIVER]
-                                 [--electron-non-patented-ffmpeg]
+                                 [--node-chromedriver-from-electron NODE_CHROMEDRIVER_FROM_ELECTRON]
+                                 [--electron-ffmpeg {archive,lib}]
+                                 [--electron-node-headers]
                                  {npm,yarn} lockfile
 
 Flatpak Node generator
@@ -57,11 +58,13 @@ optional arguments:
   -P, --no-autopatch    Don't automatically patch Git sources from
                         package*.json
   -s, --split           Split the sources file to fit onto GitHub.
-  --electron-chromedriver ELECTRON_CHROMEDRIVER
+  --node-chromedriver-from-electron NODE_CHROMEDRIVER_FROM_ELECTRON
                         Use the ChromeDriver version associated with the given
-                        Electron version
-  --electron-non-patented-ffmpeg
-                        Download the non-patented ffmpeg binaries
+                        Electron version for node-chromedriver
+  --electron-ffmpeg {archive,lib}
+                        Download the ffmpeg binaries
+  --electron-node-headers
+                        Download the electron node headers
 ```
 
 flatpak-node-generator.py takes the package manager (npm or yarn), and a path to a lockfile for

--- a/node/README.md
+++ b/node/README.md
@@ -80,6 +80,8 @@ one, each smaller than the GitHub limit.
 
 ### ChromeDriver support
 
+#### node-chromedriver
+
 If your app depends on node-chromedriver, then flatpak-node-generator will download it
 to the directory `$FLATPAK_BUILDER_BUILDDIR/flatpak-node/chromedriver`. You need to
 do two things in order to utilize this:
@@ -100,10 +102,15 @@ build-options:
 In addition, the default ChromeDriver only is available for x64. If you need to build
 on other platforms, you can use the ChromeDriver binaries that are compiled by Electron
 and distributed with their releases. To do this, pass
-`--electron-chromedriver AN_ELECTRON_VERSION` to use the ChromeDriver given with that
-Electron version. Note that you may not necessarily want to use a version here that
+`--node-chromedriver-from-electron AN_ELECTRON_VERSION` to use the ChromeDriver given with
+that Electron version. Note that you may not necessarily want to use a version here that
 corresponds to the Electron version your app is using; many apps stay on older Electron
 versions but may use newer ChromeDriver functionality.
+
+#### electron-chromedriver
+
+electron-chromedriver will be handled automatically, but make sure `ELECTRON_CACHE` is
+set as show in the quickstart examples.
 
 ### Recursive mode
 
@@ -193,9 +200,9 @@ Both of these cases are handled by the electron-webpack-quick-start example.
 
 Some node/electron versions are binary incompatible and require rebuilding of
 native node dependencies for electron. In offline mode, it may result in broken ABI.
-If you are seeing errors like 
+If you are seeing errors like
 `The module 'something.node' was compiled against a different Node.js version`,
-then pass `--electron-node-headers` option to flatpak-node-generator and set 
+then pass `--electron-node-headers` option to flatpak-node-generator and set
 `npm_config_nodedir` to `flatpak-node/node-gyp/electron-current`.
 
 ### ffmpeg support

--- a/node/README.md
+++ b/node/README.md
@@ -28,9 +28,10 @@ get npm with electron-builder.
 
 ```
 usage: flatpak-node-generator.py [-h] [-o OUTPUT] [-r] [-R RECURSIVE_PATTERN]
-                                 [--registry REGISTRY] [--no-devel]
-                                 [--no-aiohttp] [--no-requests-cache]
-                                 [--retries RETRIES] [-P] [-s]
+                                 [--registry REGISTRY] [--no-trim-index]
+                                 [--no-devel] [--no-aiohttp]
+                                 [--no-requests-cache] [--retries RETRIES]
+                                 [-P] [-s]
                                  [--node-chromedriver-from-electron NODE_CHROMEDRIVER_FROM_ELECTRON]
                                  [--electron-ffmpeg {archive,lib}]
                                  [--electron-node-headers]
@@ -52,6 +53,7 @@ optional arguments:
                         Given -r, restrict files to those matching the given
                         pattern.
   --registry REGISTRY   The registry to use (npm only)
+  --no-trim-index       Don't trim npm package metadata (npm only)
   --no-devel            Don't include devel dependencies (npm only)
   --no-aiohttp          Don't use aiohttp, and silence any warnings related to
                         it

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -851,7 +851,7 @@ class NpmLockfileProvider(LockfileProvider):
 
         for npm_prefix, url_prefix in git_prefixes.items():
             if original.startswith(npm_prefix):
-                url = url_prefix + original[len(npm_prefix) + 1:]
+                url = url_prefix + original[len(npm_prefix):]
                 break
         else:
             return None


### PR DESCRIPTION
This has been cooking for quite some time now and has some big new features:

- Package metadata is now trimmed to remove all data except for the versions that are used. This results in *massive* size reductions in the generated sources files: for Scratch, it shrank from ~170MB to around ~8MB, or **a 95% size reduction**. Idea was originally from @TingPing.
- Many requests are now cached on disk. For the Scratch Flatpak, generating the sources with a filled cache reduced the runtime from around 2 minutes and 27 seconds to just 41 seconds, which is **a 72% reduction in time**. @muelli please try it and give feedback.

Bug fixes:

- node-chromedriver works now, @Arxcis @x80486 please try. Note that upstream `@electron/get` no longer supports ELECTRON_CACHE, so I was originally working on a much bigger overhaul. However, no electron-chromedriver that's been released is using the new `@electron/get`, and it's not clear that disregarding ELECTRON_CACHE isn't actually a bug, so I'm not bothering to handle that mess yet.
- Fixed Git dependencies for Yarn, @x80486 again please try with your repo and lmk if it works.
- https://github.com/flatpak/flatpak-builder-tools/commit/47ce4294195557c92b0e91cf4c2ca0ac80ba11b9 seems to have broken Git sources at least for NPM, so I sent a fix. @muelli please try this and make sure it still works with your original reproducer for the bug.

And some cleanup:

- YAPF is used to auto format the file.
- All the boolean CLI options were refactored into options classes, to make passing them around less repetitive.