### PR TITLE
go: support "=>" lines by splitting the line from the back

### DIFF
--- a/go-get/flatpak-go-vendor-generator.py
+++ b/go-get/flatpak-go-vendor-generator.py
@@ -39,7 +39,8 @@ class GoModule:
 def parse_modules(fh):
     for line in (l.strip() for l in fh if l.strip()):
         if line.startswith("#"):
-            _, name, version = line.split(" ")
+            splits = line.split(" ")
+            name, version = splits[-2], splits[-1]
             if '-' in version:
                 version, date, revision = version.strip().split("-")
             else:


### PR DESCRIPTION
The generator did not like this line which I encountered for syncthing 1.5.0:
"# github.com/spaolacci/murmur3 v1.1.0 => github.com/twmb/murmur3 v1.1.3"

This change makes it work sufficiently well. That is, flatpak-builder
builds it fine, so I guess the dependencies were correct enough for
the build system.