### PR TITLE
node: Multiple checksums in one integrity field

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1242,7 +1242,9 @@ class YarnLockfileProvider(LockfileProvider):
             elif line.startswith('resolved'):
                 resolved = self.unquote(line.split(' ', 1)[1])
             elif line.startswith('integrity'):
-                integrity = Integrity.parse(line.split(' ', 1)[1])
+                _, values_str = line.split(' ', 1)
+                values = self.unquote(values_str).split(' ')
+                integrity = Integrity.parse(values[0])
 
         assert version and resolved, line
 

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -582,7 +582,7 @@ class ManifestGenerator(contextlib.AbstractContextManager):
         source: Dict[str, Any] = {
             'type': 'archive',
             'url': url,
-            'strip-components': 1,
+            'strip-components': strip_components,
             integrity.algorithm: integrity.digest
         }
         self._add_source_with_destination(source,


### PR DESCRIPTION
There is a possible case when one `integrity` field in `yarn.lock` contains multiple checksum-digest pairs, separated by whitespace and quoted, e.g.
```
"@types/node@*":
  version "13.1.6"
  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.6.tgz#076028d0b0400be8105b89a0a55550c86684ffec"
  integrity "sha1-B2Ao0LBAC+gQW4mgpVVQyGaE/+w= sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
```
We should handle such cases.