### PR TITLE
node: Support for XDG basedir spec cache layout

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -760,7 +760,7 @@ class SpecialSourceProvider:
             self.gen.add_command(f'mkdir -p "{cache_path.parent}"')
             self.gen.add_command(f'ln -sfTr "{self.electron_cache_dir}" "{cache_path}"')
 
-    async def _handle_node_headers(self, package: Package) -> None:
+    async def _handle_electron_headers(self, package: Package) -> None:
         if self.xdg_layout:
             node_gyp_headers_dir = self.gen.data_root / 'cache' / 'node-gyp' / package.version
         else:
@@ -904,8 +904,8 @@ class SpecialSourceProvider:
 
         if package.name == 'electron':
             await self._handle_electron(package)
-            if self.electron_node_headers:
-                await self._handle_node_headers(package)
+            if self.electron_node_headers or self.xdg_layout:
+                await self._handle_electron_headers(package)
         elif package.name == 'electron-chromedriver':
             await self._handle_electron_chromedriver(package)
         elif package.name == 'chromedriver':


### PR DESCRIPTION
Some modern versions of node-related tools start to conform XDG basedir spec to store/read their cache (i.e. respect `XDG_CACHE_HOME` env var). If all npm packages are such for given app, building this app can be made easier if put caches to exactly where packages will look for them, relative to `XDG_CACHE_HOME`.

This introduces `--xdg-layout` option that will put
- electron to `flatpak-node/cache/electron/electron-...zip` (instead of `flatpak-node/electron-cache`) 
- node-headers to `flatpak-node/cache/node-gyp/$version` (instead of `flatpak-node/node-gyp/electron-current`). 

Then, in flatpak-builder manifest, `XDG_CACHE_HOME` can be set to `/run/build/module_name/cache`. Other vars, such as `npm_config_nodedir` and `electron_config_cache` are not needed.

This is required to support multiple node-headers version during build (e.g. node-10 headers to build node-sass and run it during build, then electron-7 headers to build electron stuff).