### PR TITLE
node: Implement rc-file source provider

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1166,7 +1166,7 @@ class SpecialSourceProvider:
 
         if package.name == 'electron':
             await self._handle_electron(package)
-            if self.electron_node_headers or self.xdg_layout:
+            if self.electron_node_headers:
                 await self._handle_electron_headers(package)
         elif package.name == 'electron-chromedriver':
             await self._handle_electron_chromedriver(package)


### PR DESCRIPTION
The problem:
`.yarnrc` / `.npmrc` can define custom node.js target, so that native node modules will build against it. But since we only read lock files, there is no way for us to determine which node-headers versions are required in this case.

The proposed solution:
Read rcfiles as well, and generate sources based on their content.

I'm not sure if I took the right approach to fit in nicely to the code structure, so if not - I hope @refi64 will point me to the right direction.
This adds several new abstractions:
- `NodeHeaders` - the node version item, similar to `Package`
- `NodeHeadersProvider` - implements generation of flatpak-builder source entries based on given `NodeHeaders`
- `YarnRCFileProvider` - `.yarnrc` file parser, extracts `NodeHeaders` items