### PR TITLE
node: Create symlinks to zips for electron-get

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -738,6 +738,13 @@ class SpecialSourceProvider:
                                     binary.integrity,
                                     electron_cache_dir / binary.filename,
                                     only_arches=[binary.arch.flatpak])
+            #Symlinks for @electron/get, which stores electron zips in a subdir
+            if self.xdg_layout:
+                sanitized_url = ''.join(c for c in binary.url if c not in '/:')
+                self.gen.add_shell_source(
+                    [f'ln -s "../{binary.filename}" "{binary.filename}"'],
+                    destination=electron_cache_dir / sanitized_url,
+                    only_arches=[binary.arch.flatpak])
 
         if add_integrities:
             integrity_file = manager.integrity_file

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -610,6 +610,7 @@ class ManifestGenerator(contextlib.AbstractContextManager):
                          commands: List[str],
                          destination: Optional[Path] = None,
                          only_arches: Optional[List[str]] = None):
+        """This might be slow for multiple instances. Use `add_command()` instead."""
         source = {'type': 'shell', 'commands': tuple(commands)}
         self._add_source_with_destination(source,
                                           destination=destination,

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -606,6 +606,16 @@ class ManifestGenerator(contextlib.AbstractContextManager):
         source = {'type': 'script', 'commands': tuple(commands)}
         self._add_source_with_destination(source, destination, is_dir=False)
 
+    def add_shell_source(self,
+                         commands: List[str],
+                         destination: Optional[Path] = None,
+                         only_arches: Optional[List[str]] = None):
+        source = {'type': 'shell', 'commands': tuple(commands)}
+        self._add_source_with_destination(source,
+                                          destination=destination,
+                                          only_arches=only_arches,
+                                          is_dir=True)
+
     def add_command(self, command: str) -> None:
         self._commands.append(command)
 


### PR DESCRIPTION
`@electron/get` is the new electron binary downloader, official replacement for `electron-download` package.
It doesn't support env vars that set path to electron downloads cache, and stores downloads in a subdirectory with name based on full download url.