### PR TITLE
Use requirement parser

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -47,15 +47,15 @@ def get_pypi_url(name: str, filename: str) -> str:
 
 def get_package_name(filename: str) -> str:
     if filename.endswith(('bz2', 'gz', 'xz', 'zip')):
-        segments = filename.split("-")
+        segments = filename.split('-')
         if len(segments) == 2:
             return segments[0]
-        return "-".join(segments[:len(segments) - 1])
+        return '-'.join(segments[:len(segments) - 1])
     elif filename.endswith('whl'):
-        segments = filename.split("-")
+        segments = filename.split('-')
         if len(segments) == 5:
             return segments[0]
-        return "-".join(segments[:len(segments) - 4])
+        return '-'.join(segments[:len(segments) - 4])
     else:
         raise Exception(
             'Downloaded filename: {} does not end with bz2, gz, xz, zip, or whl'.format(filename)
@@ -73,20 +73,16 @@ def get_file_hash(filename: str) -> str:
             sha.update(data)
         return sha.hexdigest()
 
-
-if not opts.packages and not opts.requirements_file:
-    exit("Please specifiy either packages or requirements file argument")
-
 packages = []
 if opts.requirements_file and os.path.exists(opts.requirements_file):
-    with open(opts.requirements_file, "r") as req_file:
+    with open(opts.requirements_file, 'r') as req_file:
         packages = list(requirements.parse(req_file))
 elif opts.packages:
-    packages = list(requirements.parse("\n".join(opts.packages)))
+    packages = list(requirements.parse('\n'.join(opts.packages)))
 else:
-    exit("Please specifiy either packages or requirements file argument")
+    exit('Please specifiy either packages or requirements file argument')
 
-python_version = "2" if opts.python2 else "3"
+python_version = '2' if opts.python2 else '3'
 if opts.python2:
     pip_executable = 'pip2'
 else:
@@ -95,22 +91,22 @@ else:
 if opts.output:
     output_package = opts.output
 elif opts.requirements_file:
-    output_package = "python{}-{}".format(
-        python_version, opts.requirements_file.replace(".txt", ""),
+    output_package = 'python{}-{}'.format(
+        python_version, opts.requirements_file.replace('.txt', ''),
     )
 elif len(packages) == 1:
-    output_package = "python{}-{}".format(
+    output_package = 'python{}-{}'.format(
         python_version, packages[0].name,
     )
 else:
-    output_package = "python{}-modules".format(python_version)
-output_filename = output_package + ".json"
+    output_package = 'python{}-modules'.format(python_version)
+output_filename = output_package + '.json'
 
 modules = []
 
 for package in packages:
 
-    package_name = "python{}-{}".format(python_version, package.name)
+    package_name = 'python{}-{}'.format(python_version, package.name)
     tempdir_prefix = 'pip-generator-{}-'.format(package_name)
     with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         pip_download = [
@@ -149,13 +145,13 @@ for package in packages:
             # platform generic, then it forces pip to download the sdist (using
             # the --no-binary option).
             version_list = [x[0] + x[1] for x in package.specs]
-            version = ",".join(version_list)
+            version = ','.join(version_list)
 
             if package.vcs:
                 revision = ''
                 if package.revision:
                     revision = '@' + package.revision
-                pkg = package.uri + revision + "#egg=" + package.name
+                pkg = package.uri + revision + '#egg=' + package.name
             else:
                 pkg =  package.name + version
 
@@ -173,7 +169,7 @@ for package in packages:
                 sha256 = get_file_hash(os.path.join(tempdir, filename))
 
                 if package.vcs and name == package.name:
-                    url = "https://" + package.uri.split('://', 1)[1]
+                    url = 'https://' + package.uri.split('://', 1)[1]
                     s = 'commit'
                     if package.vcs == 'svn':
                         s = 'revision'
@@ -191,8 +187,8 @@ for package in packages:
                     ])
                 module['sources'].append(source)
         except subprocess.CalledProcessError:
-            print("Failed to download {}".format(package.name))
-            print("Please fix the module manually in the generated file")
+            print('Failed to download {}'.format(package.name))
+            print('Please fix the module manually in the generated file')
         modules.append(module)
 
 if len(modules) == 1:
@@ -207,4 +203,4 @@ else:
 
 with open(output_filename, 'w') as output:
     output.write(json.dumps(pypi_module, indent=4))
-    print("Output saved to {}".format(output_filename))
+    print('Output saved to {}'.format(output_filename))

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -6,11 +6,11 @@ import argparse
 import json
 import hashlib
 import os
-import re
+import requirements
 import subprocess
 import tempfile
 import urllib.request
-import shlex
+
 from collections import OrderedDict
 
 
@@ -61,6 +61,7 @@ def get_package_name(filename: str) -> str:
             'Downloaded filename: {} does not end with bz2, gz, xz, zip, or whl'.format(filename)
         )
 
+
 def get_file_hash(filename: str) -> str:
     sha = hashlib.sha256()
     print('Generating hash for', filename)
@@ -78,36 +79,38 @@ if not opts.packages and not opts.requirements_file:
 
 packages = []
 if opts.requirements_file and os.path.exists(opts.requirements_file):
-    with open(opts.requirements_file, 'r') as req_file:
-        packages = [package.strip() for package in req_file.readlines()]
+    with open(opts.requirements_file, "r") as req_file:
+        packages = list(requirements.parse(req_file))
+elif opts.packages:
+    packages = list(requirements.parse("\n".join(opts.packages)))
 else:
-    packages = opts.packages
+    exit("Please specifiy either packages or requirements file argument")
 
-
+python_version = "2" if opts.python2 else "3"
 if opts.python2:
     pip_executable = 'pip2'
 else:
     pip_executable = 'pip3'
 
+if opts.output:
+    output_package = opts.output
+elif opts.requirements_file:
+    output_package = "python{}-{}".format(
+        python_version, opts.requirements_file.replace(".txt", ""),
+    )
+elif len(packages) == 1:
+    output_package = "python{}-{}".format(
+        python_version, packages[0].name,
+    )
+else:
+    output_package = "python{}-modules".format(python_version)
+output_filename = output_package + ".json"
+
 modules = []
 
 for package in packages:
-    if '#' in package:
-        vcs_details = re.split(r'\#|\&', package)
-        r = re.compile("egg=.*")
-        for egg_name in list(filter(r.match, vcs_details)):
-            package_name = re.search('^egg=(.*?)$', egg_name).group(1)
-            if package_name:
-                break
-        else:
-            package_name = os.path.basename(re.search('(.*?)#', x).group(1))
-        vsc_name = package_name
-        vsc_url = package
-    else:
-        package_name = 'python{}-{}'.format('2' if opts.python2 else '3',
-                                            package.split("=")[0])
-        vsc_name = None
-        vsc_url = None
+
+    package_name = "python{}-{}".format(python_version, package.name)
     tempdir_prefix = 'pip-generator-{}-'.format(package_name)
     with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         pip_download = [
@@ -124,7 +127,7 @@ for package in packages:
             '--no-index',
             '--find-links="file://${PWD}"',
             '--prefix=${FLATPAK_DEST}',
-            package
+            package.name
         ]
         if opts.no_build_isolation:
             pip_command.append('--no-build-isolation')
@@ -145,38 +148,52 @@ for package in packages:
             # select the preferred package, if the package downloaded is not
             # platform generic, then it forces pip to download the sdist (using
             # the --no-binary option).
-            subprocess.run(pip_download + [package], check=True)
+            version_list = [x[0] + x[1] for x in package.specs]
+            version = ",".join(version_list)
+
+            if package.vcs:
+                revision = ''
+                if package.revision:
+                    revision = '@' + package.revision
+                pkg = package.uri + revision + "#egg=" + package.name
+            else:
+                pkg =  package.name + version
+
+            subprocess.run(pip_download + [pkg], check=True)
             for filename in os.listdir(tempdir):
                 if not filename.endswith(('gz', 'any.whl')):
                     os.remove(os.path.join(tempdir, filename))
                     subprocess.run(pip_download + [
-                        '--no-binary', ':all:', package
+                        '--no-binary', ':all:', pkg
                     ], check=True)
             for filename in os.listdir(tempdir):
                 name = get_package_name(filename)
                 if name == 'setuptools':  # Already installed
                     continue
                 sha256 = get_file_hash(os.path.join(tempdir, filename))
-                if name == vsc_name:
-                    url = vsc_url
+
+                if package.vcs and name == package.name:
+                    url = "https://" + package.uri.split('://', 1)[1]
+                    s = 'commit'
+                    if package.vcs == 'svn':
+                        s = 'revision'
+                    source = OrderedDict([
+                        ('type', package.vcs),
+                        ('url', url),
+                        (s, package.revision),
+                    ])
                 else:
                     url = get_pypi_url(name, filename)
-                source = OrderedDict([
-                    ('type', 'file'),
-                    ('url', url),
-                    ('sha256', sha256),
-                ])
+                    source = OrderedDict([
+                        ('type', 'file'),
+                        ('url', url),
+                        ('sha256', sha256),
+                    ])
                 module['sources'].append(source)
         except subprocess.CalledProcessError:
-            print("Failed to download {}".format(package))
+            print("Failed to download {}".format(package.name))
             print("Please fix the module manually in the generated file")
         modules.append(module)
-
-if opts.requirements_file:
-    output_package = opts.output or 'pypi-dependencies'
-else:
-    output_package = opts.output or package_name
-output_filename = output_package + '.json'
 
 if len(modules) == 1:
     pypi_module = modules[0]
@@ -190,3 +207,4 @@ else:
 
 with open(output_filename, 'w') as output:
     output.write(json.dumps(pypi_module, indent=4))
+    print("Output saved to {}".format(output_filename))

--- a/pip/readme.md
+++ b/pip/readme.md
@@ -1,21 +1,25 @@
 # Flatpak PIP Generator
 
-Tool to automatically generate `flatpak-builder` manifest json from a `pip` package-name.
+Tool to automatically generate `flatpak-builder` manifest json from a `pip`
+package-name. Requires `requirements-parser`.
 
 ## Usage
 
-`flatpak-pip-generator foo` which generates `foo.json` and can be included in a manifest like:
+`flatpak-pip-generator foo` which generates `python3-foo.json` and can be included in a manifest like:
 
 ```json
 "modules": [
-  "foo.json",
+  "python3-foo.json",
   {
     "name": "other-modules"
   }
 ]
 ```
 
-You can also list multiple packages in single command.
+You can also list multiple packages in single command:
+```
+flatpak-pip-generator foo\>=1.0.0,\<2.0.0 bar 
+```
 
 If your project contains a [requirements.txt file](https://pip.readthedocs.io/en/stable/user_guide/#requirements-files) with all the project dependencies, you can use 
 ```


### PR DESCRIPTION
* Fixes #102
* Correctly names modules, e.g. occurrences of `"name": "python3-foo>"`
* If foo.txt is supplied output is named python3-foo.json
* For multiple modules output is named python3-modules.json
* Added instructions for multiple packages with versions in readme
* Tells the user the name of the output json file
* CVS generates a "git" type source, but won't build