### PR TITLE
pip: Fixes pip3 install command for vcs packages and extras

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -118,6 +118,9 @@ for package in packages:
         ]
 
         name_for_pip = package.name
+        if len(package.extras) > 0:
+            extras = ', '.join(extra for extra in package.extras)
+            name_for_pip = name_for_pip + '[' + extras + ']'
         if package.vcs:
             name_for_pip = '.'
 

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -116,6 +116,11 @@ for package in packages:
             '--dest',
             tempdir
         ]
+
+        name_for_pip = package.name
+        if package.vcs:
+            name_for_pip = '.'
+
         pip_command = [
             pip_executable,
             'install',
@@ -123,7 +128,7 @@ for package in packages:
             '--no-index',
             '--find-links="file://${PWD}"',
             '--prefix=${FLATPAK_DEST}',
-            package.name
+            name_for_pip
         ]
         if opts.no_build_isolation:
             pip_command.append('--no-build-isolation')


### PR DESCRIPTION
Tested with
```sh
# requirements.txt
git+git://github.com/psf/requests.git@c7e0fc087ceeadb8b4c84a0953a422c474093d6#egg=requests
certifi
```
produces a `json` file which is correctly builded with `flatpak-builder`. I am not convinced by the variable `name_for_pip` name.