### PR TITLE
pip: Correctly fetches sources with extras

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -124,9 +124,10 @@ for package in packages:
         ]
 
         name_for_pip = package.name
+        extras = ''
         if len(package.extras) > 0:
-            extras = ', '.join(extra for extra in package.extras)
-            name_for_pip = name_for_pip + '[' + extras + ']'
+            extras = '[' + ','.join(extra for extra in package.extras) + ']'
+            name_for_pip = name_for_pip + extras
         if package.vcs:
             name_for_pip = '.'
 
@@ -167,7 +168,7 @@ for package in packages:
                     revision = '@' + package.revision
                 pkg = package.uri + revision + '#egg=' + package.name
             else:
-                pkg =  package.name + version
+                pkg = package.name + extras + version
 
             subprocess.run(pip_download + [pkg], check=True)
             for filename in os.listdir(tempdir):


### PR DESCRIPTION
It was only fetching by package name instead of package[extra1,extra2], this together with #135
allow to get correctly generate manifests. Tested with the following requirements.txt
``` sh
# Some comment
Cython # Other comment, and whitespace

qdarkstyle==2.8
pyaes>=0.1a1
git+git://github.com/psf/requests.git@c7e0fc087ceeadb8b4c84a0953a422c474093d6#egg=requests
aiorpcx>=0.18,<0.19
requests[security,socks]>=2.8.1
```
It was also tested without the first apperance of `requests`. It is tempting to use the same variable for fetching `name_for_pip= name + extras + version` and installing `pkg= name + extras`, but the later breaks `flatpak-builder` when versions are added.