### PR TITLE
pip: Refactor how sources are generated 

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -79,7 +79,10 @@ def parse_continuation_lines(fin):
     for line in fin:
         line = line.rstrip('\n')
         while line.endswith('\\'):
-            line = line[:-1] + next(fin).rstrip('\n')
+            try:
+                line = line[:-1] + next(fin).rstrip('\n')
+            except StopIteration:
+                exit('Requirements have a wrong number of line continuation characters "\\"')
         yield line
 
 

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -139,7 +139,6 @@ output_filename = output_package + '.json'
 modules = []
 vcs_modules = []
 sources = {}
-vcs_sources = {}
 
 tempdir_prefix = 'pip-generator-{}'.format(output_filename.replace('.json', ''))
 with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
@@ -224,14 +223,15 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
                 ('url', url),
                 (s, revision),
             ])
-            vcs_sources[name] = {'source': source}
+            is_vcs = True
         else:
             url = get_pypi_url(name, filename)
             source = OrderedDict([
                 ('type', 'file'),
                 ('url', url),
                 ('sha256', sha256)])
-            sources[name] = {'source': source}
+            is_vcs = False
+        sources[name] = {'source': source, 'vcs': is_vcs}
 
 # Python3 packages that come as part of org.freedesktop.Sdk.
 system_packages = ['Mako', 'Markdown', 'meson', 'pip', 'setuptools', 'six']
@@ -281,15 +281,17 @@ for package in packages:
         except subprocess.CalledProcessError:
             print('Failed to download {}'.format(package.name))
 
-    package_sources = [sources[x]['source'] for x in dependencies if x in sources]
-    vcs_package_sources = [vcs_sources[x]['source'] for x in dependencies if x in vcs_sources]
+    is_vcs = True if package.vcs else False
+    package_sources = [sources[x]['source']
+                       for x in dependencies
+                       if x in sources
+                       # Add vcs source only if package is vcs
+                       and (not sources[x]['vcs'] or is_vcs)]
 
     if package.vcs:
         name_for_pip = '.'
-        vcs_s = vcs_package_sources
     else:
         name_for_pip = pkg
-        vcs_s = []
 
     module_name = 'python{}-{}'.format(python_version, package.name)
 
@@ -309,7 +311,7 @@ for package in packages:
         ('name', module_name),
         ('buildsystem', 'simple'),
         ('build-commands', [' '.join(pip_command)]),
-        ('sources', vcs_s + package_sources),
+        ('sources', package_sources),
     ])
     if opts.cleanup == 'all':
         module['cleanup'] = ['*']

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -83,11 +83,29 @@ def parse_continuation_lines(fin):
         yield line
 
 
+def parse_hashes(line):
+    name = line.split(" ")[0]
+    hash_requirements = []
+    while "--hash=" in line:
+        split = line.split("--hash=", 1)
+        hash_algorithm = split[1].split(":", 1)[0]
+        hash_value = split[1].split(":", 1)[1].split(" ", 1)[0]
+        line = line.replace('--hash=' + hash_algorithm + ":" + hash_value, '')
+        hash_requirements.append([hash_algorithm.lower(), hash_value])
+    return name, hash_requirements
+
+
 packages = []
 if opts.requirements_file and os.path.exists(opts.requirements_file):
     with open(opts.requirements_file, 'r') as req_file:
-        reqs = parse_continuation_lines(req_file)
-        packages = list(requirements.parse(reqs))
+        reqs = list(parse_continuation_lines(req_file))
+        for i, line in enumerate(reqs):
+            if '--hash' in line:
+                use_hash = True
+                package_name, hash_requirements = parse_hashes(line)
+                reqs[i] = package_name
+        reqs_as_str = "\n".join(reqs)
+        packages = list(requirements.parse(reqs_as_str))
 elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))
 else:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -86,29 +86,11 @@ def parse_continuation_lines(fin):
         yield line
 
 
-def parse_hashes(line):
-    name = line.split(' ')[0]
-    hash_requirements = []
-    while '--hash=' in line:
-        split = line.split('--hash=', 1)
-        hash_algorithm = split[1].split(':', 1)[0]
-        hash_value = split[1].split(':', 1)[1].split(' ', 1)[0]
-        line = line.replace('--hash=' + hash_algorithm + ':' + hash_value, '')
-        hash_requirements.append([hash_algorithm.lower(), hash_value])
-    return name, hash_requirements
-
-
 packages = []
-use_hash = False
 if opts.requirements_file and os.path.exists(opts.requirements_file):
     with open(opts.requirements_file, 'r') as req_file:
-        reqs = list(parse_continuation_lines(req_file))
-        for i, line in enumerate(reqs):
-            if '--hash' in line:
-                use_hash = True
-                package_name, hash_requirements = parse_hashes(line)
-                reqs[i] = package_name
-        reqs_as_str = '\n'.join(reqs)
+        reqs = parse_continuation_lines(req_file)
+        reqs_as_str = '\n'.join([r.split('--hash')[0] for r in reqs])
         packages = list(requirements.parse(reqs_as_str))
         requirements_file = opts.requirements_file
 elif opts.packages:
@@ -116,9 +98,11 @@ elif opts.packages:
     with tempfile.NamedTemporaryFile('w', delete=False) as req_file:
         req_file.write('\n'.join(opts.packages))
         requirements_file = req_file.name
-
 else:
     exit('Please specifiy either packages or requirements file argument')
+
+with open(requirements_file, 'r') as req_file:
+    use_hash = '--hash=' in req_file.read()
 
 python_version = '2' if opts.python2 else '3'
 if opts.python2:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -138,11 +138,10 @@ output_filename = output_package + '.json'
 
 modules = []
 vcs_modules = []
-sources = []
-vcs_sources = []
+sources = {}
+vcs_sources = {}
 
 tempdir_prefix = 'pip-generator-{}'.format(output_filename.replace('.json', ''))
-
 with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
     pip_download = [
         pip_executable,
@@ -225,14 +224,14 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
                 ('url', url),
                 (s, revision),
             ])
-            vcs_sources.append(source)
+            vcs_sources[name] = {'source': source}
         else:
             url = get_pypi_url(name, filename)
             source = OrderedDict([
                 ('type', 'file'),
                 ('url', url),
                 ('sha256', sha256)])
-            sources.append(source)
+            sources[name] = {'source': source}
 
 # Python3 packages that come as part of org.freedesktop.Sdk.
 system_packages = ['Mako', 'Markdown', 'meson', 'pip', 'setuptools', 'six']
@@ -261,9 +260,33 @@ for package in packages:
     else:
         pkg = package.name + extras + version
 
+    dependencies = []
+    # Downloads the package again to list dependencies
+
+    tempdir_prefix = 'pip-generator-{}'.format(package.name)
+    with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
+        pip_download = [
+            pip_executable,
+            'download',
+            '--exists-action=i',
+            '--dest',
+            tempdir,
+        ]
+        try:
+            print('Generating dependencies for {}'.format(package.name))
+            subprocess.run(pip_download + [pkg], check=True, stdout=subprocess.DEVNULL)
+            for filename in os.listdir(tempdir):
+                dependencies.append(get_package_name(filename))
+
+        except subprocess.CalledProcessError:
+            print('Failed to download {}'.format(package.name))
+
+    package_sources = [sources[x]['source'] for x in dependencies if x in sources]
+    vcs_package_sources = [vcs_sources[x]['source'] for x in dependencies if x in vcs_sources]
+
     if package.vcs:
         name_for_pip = '.'
-        vcs_s = vcs_sources
+        vcs_s = vcs_package_sources
     else:
         name_for_pip = pkg
         vcs_s = []
@@ -286,7 +309,7 @@ for package in packages:
         ('name', module_name),
         ('buildsystem', 'simple'),
         ('build-commands', [' '.join(pip_command)]),
-        ('sources', vcs_s + sources),
+        ('sources', vcs_s + package_sources),
     ])
     if opts.cleanup == 'all':
         module['cleanup'] = ['*']

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -106,8 +106,12 @@ if opts.requirements_file and os.path.exists(opts.requirements_file):
                 reqs[i] = package_name
         reqs_as_str = "\n".join(reqs)
         packages = list(requirements.parse(reqs_as_str))
+        requirements_file = opts.requirements_file
 elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))
+    requirements_file = '/tmp/flatpak-pip-generator-requirements.txt'
+    with open(requirements_file, 'w') as req_file:
+        req_file.writelines('\n'.join(opts.packages))
 else:
     exit('Please specifiy either packages or requirements file argument')
 

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -87,35 +87,36 @@ def parse_continuation_lines(fin):
 
 
 def parse_hashes(line):
-    name = line.split(" ")[0]
+    name = line.split(' ')[0]
     hash_requirements = []
-    while "--hash=" in line:
-        split = line.split("--hash=", 1)
-        hash_algorithm = split[1].split(":", 1)[0]
-        hash_value = split[1].split(":", 1)[1].split(" ", 1)[0]
-        line = line.replace('--hash=' + hash_algorithm + ":" + hash_value, '')
+    while '--hash=' in line:
+        split = line.split('--hash=', 1)
+        hash_algorithm = split[1].split(':', 1)[0]
+        hash_value = split[1].split(':', 1)[1].split(' ', 1)[0]
+        line = line.replace('--hash=' + hash_algorithm + ':' + hash_value, '')
         hash_requirements.append([hash_algorithm.lower(), hash_value])
     return name, hash_requirements
 
 
 packages = []
-use_hash = None
+use_hash = False
 if opts.requirements_file and os.path.exists(opts.requirements_file):
     with open(opts.requirements_file, 'r') as req_file:
         reqs = list(parse_continuation_lines(req_file))
         for i, line in enumerate(reqs):
             if '--hash' in line:
-                use_hash = '--require-hashes'
+                use_hash = True
                 package_name, hash_requirements = parse_hashes(line)
                 reqs[i] = package_name
-        reqs_as_str = "\n".join(reqs)
+        reqs_as_str = '\n'.join(reqs)
         packages = list(requirements.parse(reqs_as_str))
         requirements_file = opts.requirements_file
 elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))
-    requirements_file = '/tmp/flatpak-pip-generator-requirements.txt'
-    with open(requirements_file, 'w') as req_file:
-        req_file.writelines('\n'.join(opts.packages))
+    with tempfile.NamedTemporaryFile('w', delete=False) as req_file:
+        req_file.write('\n'.join(opts.packages))
+        requirements_file = req_file.name
+
 else:
     exit('Please specifiy either packages or requirements file argument')
 
@@ -156,7 +157,7 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
     ]
 
     if use_hash:
-        pip_download.append(use_hash)
+        pip_download.append('--require-hashes')
 
     try:
         # May download the package twice, the first time it allows pip to

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -21,14 +21,14 @@ parser.add_argument('--python2', action='store_true',
                     help='Look for a Python 2 package')
 parser.add_argument('--cleanup', choices=['scripts', 'all'],
                     help='Select what to clean up after build')
-parser.add_argument('--requirements-file',
+parser.add_argument('--requirements-file', '-r',
                     help='Specify requirements.txt file')
 parser.add_argument('--build-only', action='store_const',
                     dest='cleanup', const='all',
                     help='Clean up all files after build')
 parser.add_argument('--no-build-isolation',
                     help='https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support')
-parser.add_argument('--output',
+parser.add_argument('--output', '-o',
                     help='Specify output file name')
 opts = parser.parse_args()
 

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -8,9 +8,9 @@ import hashlib
 import os
 import requirements
 import subprocess
+import sys
 import tempfile
 import urllib.request
-import sys
 
 from collections import OrderedDict
 
@@ -96,12 +96,13 @@ def parse_hashes(line):
 
 
 packages = []
+use_hash = None
 if opts.requirements_file and os.path.exists(opts.requirements_file):
     with open(opts.requirements_file, 'r') as req_file:
         reqs = list(parse_continuation_lines(req_file))
         for i, line in enumerate(reqs):
             if '--hash' in line:
-                use_hash = True
+                use_hash = '--require-hashes'
                 package_name, hash_requirements = parse_hashes(line)
                 reqs[i] = package_name
         reqs_as_str = "\n".join(reqs)
@@ -136,6 +137,101 @@ else:
 output_filename = output_package + '.json'
 
 modules = []
+sources = []
+
+tempdir_prefix = 'pip-generator-{}'.format(output_filename.replace('.json', ''))
+
+with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
+    pip_download = [
+        pip_executable,
+        'download',
+        '--exists-action=i',
+        '--dest',
+        tempdir,
+        '-r',
+        requirements_file
+    ]
+
+    if use_hash:
+        pip_download.append(use_hash)
+
+    try:
+        # May download the package twice, the first time it allows pip to
+        # select the preferred package, if the package downloaded is not
+        # platform generic, then it forces pip to download the sdist (using
+        # the --no-binary option).
+
+        subprocess.run(pip_download, check=True)
+        for filename in os.listdir(tempdir):
+            if not filename.endswith(('gz', 'any.whl', 'zip')):
+                os.remove(os.path.join(tempdir, filename))
+
+        subprocess.run(pip_download + [
+            '--no-binary', ':all:'
+            ], check=True)
+
+    except subprocess.CalledProcessError:
+        print('Failed to download')
+        print('Please fix the module manually in the generated file')
+
+    files = {get_package_name(f): [] for f in os.listdir(tempdir)}
+
+    for filename in os.listdir(tempdir):
+        name = get_package_name(filename)
+        files[name].append(filename)
+
+    # Delete redundant sources, where .zip (vcs sources) take precedence
+    # over .whl, and .whl over tar.gz sources.
+    for name in files:
+        if len(files[name]) > 1:
+            whl_source = False
+            zip_source = False
+            for f in files[name]:
+                if f.endswith(('any.whl')):
+                    whl_source = True
+                if f.endswith(('.zip')):
+                    zip_source = True
+            if zip_source:
+                for f in files[name]:
+                    if not f.endswith(('.zip')):
+                        os.remove(os.path.join(tempdir, f))
+            elif whl_source:
+                for f in files[name]:
+                    if not f.endswith(('any.whl')):
+                        os.remove(os.path.join(tempdir, f))
+
+    vcs_packages = {
+        x.name: {'vcs': x.vcs, 'revision': x.revision, 'uri': x.uri}
+        for x in packages
+        if x.vcs
+    }
+
+    for filename in os.listdir(tempdir):
+        name = get_package_name(filename)
+        if name == 'setuptools':  # Already installed
+            continue
+        sha256 = get_file_hash(os.path.join(tempdir, filename))
+
+        if name in vcs_packages:
+            uri = vcs_packages[name]['uri']
+            revision = vcs_packages[name]['revision']
+            vcs = vcs_packages[name]['vcs']
+            url = 'https://' + uri.split('://', 1)[1]
+            s = 'commit'
+            if vcs == 'svn':
+                s = 'revision'
+            source = OrderedDict([
+                ('type', vcs),
+                ('url', url),
+                (s, revision),
+            ])
+        else:
+            url = get_pypi_url(name, filename)
+            source = OrderedDict([
+                ('type', 'file'),
+                ('url', url),
+                ('sha256', sha256)])
+        sources.append(source)
 
 for package in packages:
 
@@ -144,102 +240,56 @@ for package in packages:
         print('Append #egg=<pkgname> to the end of the requirement line to fix', file=sys.stderr)
         continue
 
-    package_name = 'python{}-{}'.format(python_version, package.name)
-    tempdir_prefix = 'pip-generator-{}-'.format(package_name)
-    with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
-        pip_download = [
-            pip_executable,
-            'download',
-            '--exists-action=i',
-            '--dest',
-            tempdir
-        ]
+    if len(package.extras) > 0:
+        extras = '[' + ','.join(extra for extra in package.extras) + ']'
+    else:
+        extras = ''
 
-        if len(package.extras) > 0:
-            extras = '[' + ','.join(extra for extra in package.extras) + ']'
-        else:
-            extras = ''
+    version_list = [x[0] + x[1] for x in package.specs]
+    version = ','.join(version_list)
 
-        version_list = [x[0] + x[1] for x in package.specs]
-        version = ','.join(version_list)
+    if package.vcs:
+        revision = ''
+        if package.revision:
+            revision = '@' + package.revision
+        pkg = package.uri + revision + '#egg=' + package.name
+    else:
+        pkg = package.name + extras + version
 
-        if package.vcs:
-            revision = ''
-            if package.revision:
-                revision = '@' + package.revision
-            pkg = package.uri + revision + '#egg=' + package.name
-        else:
-            pkg = package.name + extras + version
+    if package.vcs:
+        name_for_pip = '.'
+    else:
+        name_for_pip = pkg
 
-        if package.vcs:
-            name_for_pip = '.'
-        else:
-            name_for_pip = pkg
+    module_name = 'python{}-{}'.format(python_version, package.name)
 
-        pip_command = [
-            pip_executable,
-            'install',
-            '--exists-action=i',
-            '--no-index',
-            '--find-links="file://${PWD}"',
-            '--prefix=${FLATPAK_DEST}',
-            '"{}"'.format(name_for_pip)
-        ]
-        if opts.no_build_isolation:
-            pip_command.append('--no-build-isolation')
-        module = OrderedDict([
-            ('name', package_name),
-            ('buildsystem', 'simple'),
-            ('build-commands', [' '.join(pip_command)]),
-            ('sources', []),
-        ])
+    pip_command = [
+        pip_executable,
+        'install',
+        '--exists-action=i',
+        '--no-index',
+        '--find-links="file://${PWD}"',
+        '--prefix=${FLATPAK_DEST}',
+        '"{}"'.format(name_for_pip)
+    ]
+    if opts.no_build_isolation:
+        pip_command.append('--no-build-isolation')
+    module = OrderedDict([
+        ('name', module_name),
+        ('buildsystem', 'simple'),
+        ('build-commands', [' '.join(pip_command)]),
+        ('sources', sources),
+    ])
+    if opts.cleanup == 'all':
+        module['cleanup'] = ['*']
+    elif opts.cleanup == 'scripts':
+        module['cleanup'] = ['/bin', '/share/man/man1']
 
-        if opts.cleanup == 'all':
-            module['cleanup'] = ['*']
-        elif opts.cleanup == 'scripts':
-            module['cleanup'] = ['/bin', '/share/man/man1']
+    modules.append(module)
 
-        try:
-            # May download the package twice, the first time it allows pip to
-            # select the preferred package, if the package downloaded is not
-            # platform generic, then it forces pip to download the sdist (using
-            # the --no-binary option).
-
-            subprocess.run(pip_download + [pkg], check=True)
-            for filename in os.listdir(tempdir):
-                if not filename.endswith(('gz', 'any.whl')):
-                    os.remove(os.path.join(tempdir, filename))
-                    subprocess.run(pip_download + [
-                        '--no-binary', ':all:', pkg
-                    ], check=True)
-            for filename in os.listdir(tempdir):
-                name = get_package_name(filename)
-                if name == 'setuptools':  # Already installed
-                    continue
-                sha256 = get_file_hash(os.path.join(tempdir, filename))
-
-                if package.vcs and name == package.name:
-                    url = 'https://' + package.uri.split('://', 1)[1]
-                    s = 'commit'
-                    if package.vcs == 'svn':
-                        s = 'revision'
-                    source = OrderedDict([
-                        ('type', package.vcs),
-                        ('url', url),
-                        (s, package.revision),
-                    ])
-                else:
-                    url = get_pypi_url(name, filename)
-                    source = OrderedDict([
-                        ('type', 'file'),
-                        ('url', url),
-                        ('sha256', sha256),
-                    ])
-                module['sources'].append(source)
-        except subprocess.CalledProcessError:
-            print('Failed to download {}'.format(package.name))
-            print('Please fix the module manually in the generated file')
-        modules.append(module)
+if requirements_file == '/tmp/flatpak-pip-generator-requirements.txt':
+    if os.path.exists(requirements_file):
+        os.remove(requirements_file)
 
 if len(modules) == 1:
     pypi_module = modules[0]

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -311,9 +311,8 @@ for package in packages:
     else:
         modules.append(module)
 
-if requirements_file == '/tmp/flatpak-pip-generator-requirements.txt':
-    if os.path.exists(requirements_file):
-        os.remove(requirements_file)
+if not opts.requirements_file and os.path.exists(requirements_file):
+    os.remove(requirements_file)
 
 modules = vcs_modules + modules
 if len(modules) == 1:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -151,13 +151,26 @@ for package in packages:
             tempdir
         ]
 
-        name_for_pip = package.name
-        extras = ''
         if len(package.extras) > 0:
             extras = '[' + ','.join(extra for extra in package.extras) + ']'
-            name_for_pip = name_for_pip + extras
+        else:
+            extras = ''
+
+        version_list = [x[0] + x[1] for x in package.specs]
+        version = ','.join(version_list)
+
+        if package.vcs:
+            revision = ''
+            if package.revision:
+                revision = '@' + package.revision
+            pkg = package.uri + revision + '#egg=' + package.name
+        else:
+            pkg = package.name + extras + version
+
         if package.vcs:
             name_for_pip = '.'
+        else:
+            name_for_pip = pkg
 
         pip_command = [
             pip_executable,
@@ -166,7 +179,7 @@ for package in packages:
             '--no-index',
             '--find-links="file://${PWD}"',
             '--prefix=${FLATPAK_DEST}',
-            name_for_pip
+            '"{}"'.format(name_for_pip)
         ]
         if opts.no_build_isolation:
             pip_command.append('--no-build-isolation')
@@ -187,16 +200,6 @@ for package in packages:
             # select the preferred package, if the package downloaded is not
             # platform generic, then it forces pip to download the sdist (using
             # the --no-binary option).
-            version_list = [x[0] + x[1] for x in package.specs]
-            version = ','.join(version_list)
-
-            if package.vcs:
-                revision = ''
-                if package.revision:
-                    revision = '@' + package.revision
-                pkg = package.uri + revision + '#egg=' + package.name
-            else:
-                pkg = package.name + extras + version
 
             subprocess.run(pip_download + [pkg], check=True)
             for filename in os.listdir(tempdir):

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -208,8 +208,6 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
 
     for filename in os.listdir(tempdir):
         name = get_package_name(filename)
-        if name == 'setuptools':  # Already installed
-            continue
         sha256 = get_file_hash(os.path.join(tempdir, filename))
 
         if name in vcs_packages:
@@ -233,11 +231,15 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
                 ('sha256', sha256)])
         sources.append(source)
 
+# Python3 packages that come as part of org.freedesktop.Sdk.
+system_packages = ['Mako', 'Markdown', 'meson', 'pip', 'setuptools', 'six']
 for package in packages:
 
     if package.name is None:
         print('Warning: skipping invalid requirement specification {} because it is missing a name'.format(package.line), file=sys.stderr)
         print('Append #egg=<pkgname> to the end of the requirement line to fix', file=sys.stderr)
+        continue
+    elif package.name in system_packages:
         continue
 
     if len(package.extras) > 0:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -311,8 +311,11 @@ for package in packages:
     else:
         modules.append(module)
 
-if not opts.requirements_file and os.path.exists(requirements_file):
-    os.remove(requirements_file)
+if not opts.requirements_file:
+    try:
+        os.remove(requirements_file)
+    except FileNotFoundError:
+        pass
 
 modules = vcs_modules + modules
 if len(modules) == 1:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -74,10 +74,20 @@ def get_file_hash(filename: str) -> str:
             sha.update(data)
         return sha.hexdigest()
 
+
+def parse_continuation_lines(fin):
+    for line in fin:
+        line = line.rstrip('\n')
+        while line.endswith('\\'):
+            line = line[:-1] + next(fin).rstrip('\n')
+        yield line
+
+
 packages = []
 if opts.requirements_file and os.path.exists(opts.requirements_file):
     with open(opts.requirements_file, 'r') as req_file:
-        packages = list(requirements.parse(req_file))
+        reqs = parse_continuation_lines(req_file)
+        packages = list(requirements.parse(reqs))
 elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))
 else:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -137,7 +137,9 @@ else:
 output_filename = output_package + '.json'
 
 modules = []
+vcs_modules = []
 sources = []
+vcs_sources = []
 
 tempdir_prefix = 'pip-generator-{}'.format(output_filename.replace('.json', ''))
 
@@ -223,13 +225,14 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
                 ('url', url),
                 (s, revision),
             ])
+            vcs_sources.append(source)
         else:
             url = get_pypi_url(name, filename)
             source = OrderedDict([
                 ('type', 'file'),
                 ('url', url),
                 ('sha256', sha256)])
-        sources.append(source)
+            sources.append(source)
 
 # Python3 packages that come as part of org.freedesktop.Sdk.
 system_packages = ['Mako', 'Markdown', 'meson', 'pip', 'setuptools', 'six']
@@ -260,8 +263,10 @@ for package in packages:
 
     if package.vcs:
         name_for_pip = '.'
+        vcs_s = vcs_sources
     else:
         name_for_pip = pkg
+        vcs_s = []
 
     module_name = 'python{}-{}'.format(python_version, package.name)
 
@@ -276,23 +281,28 @@ for package in packages:
     ]
     if opts.no_build_isolation:
         pip_command.append('--no-build-isolation')
+
     module = OrderedDict([
         ('name', module_name),
         ('buildsystem', 'simple'),
         ('build-commands', [' '.join(pip_command)]),
-        ('sources', sources),
+        ('sources', vcs_s + sources),
     ])
     if opts.cleanup == 'all':
         module['cleanup'] = ['*']
     elif opts.cleanup == 'scripts':
         module['cleanup'] = ['/bin', '/share/man/man1']
 
-    modules.append(module)
+    if package.vcs:
+        vcs_modules.append(module)
+    else:
+        modules.append(module)
 
 if requirements_file == '/tmp/flatpak-pip-generator-requirements.txt':
     if os.path.exists(requirements_file):
         os.remove(requirements_file)
 
+modules = vcs_modules + modules
 if len(modules) == 1:
     pypi_module = modules[0]
 else:


### PR DESCRIPTION
DONE: ~~Find a way to list the sources files only once.~~
 with this PR the ALL sources will be listed once for each package. One possibility is to, instead of doing one module per package, do a single module with all packages. This would drastically decrease the length of the output file, even compared with `flatpak-pip-generator` before this PR, but we lose the ability to take off from the last built module in `flatpak-builder`.