### PR TITLE
pip: Eliminate calls of `pip download --no-binary`

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -70,6 +70,7 @@ def get_package_name(filename: str) -> str:
             return segments[0]
         candidate = segments[:len(segments) - 4]
         # Some packages list the version number twice
+        # e.g. PyQt5-5.15.0-5.15.0-cp35.cp36.cp37.cp38-abi3-manylinux2014_x86_64.whl
         if candidate[-1] == segments[len(segments) - 4]:
             return '-'.join(candidate[:-1])
         return '-'.join(candidate)

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -6,7 +6,6 @@ import argparse
 import json
 import hashlib
 import os
-import requirements
 import shutil
 import subprocess
 import sys
@@ -149,6 +148,10 @@ if not opts.python2:
 
 packages = []
 if opts.requirements_file and os.path.exists(opts.requirements_file):
+    try:
+        import requirements
+    except ImportError:
+        exit('Requirements modules is not installed. Run "pip install requirements-parser"')
     with open(opts.requirements_file, 'r') as req_file:
         reqs = parse_continuation_lines(req_file)
         reqs_as_str = '\n'.join([r.split('--hash')[0] for r in reqs])

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -7,6 +7,7 @@ import json
 import hashlib
 import os
 import requirements
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -46,6 +47,15 @@ def get_pypi_url(name: str, filename: str) -> str:
             raise Exception('Failed to extract url from {}'.format(url))
 
 
+def get_tar_package_url_pypi(name: str, version: str) -> str:
+    url = 'https://pypi.org/pypi/{}/{}/json'.format(name, version)
+    with urllib.request.urlopen(url) as response:
+        body = json.loads(response.read().decode('utf-8'))
+        for url in body['urls']:
+            if url['url'].endswith(('any.whl', 'gz', 'zip')):
+                return url['url']
+
+
 def get_package_name(filename: str) -> str:
     if filename.endswith(('bz2', 'gz', 'xz', 'zip')):
         segments = filename.split('-')
@@ -63,6 +73,15 @@ def get_package_name(filename: str) -> str:
         )
 
 
+def get_file_version(filename: str) -> str:
+    name = get_package_name(filename)
+    segments = filename.split(name + '-')
+    version = segments[1].split('-')[0]
+    for ext in ['tar.gz', 'whl', 'tar.xz', 'tar.gz', 'tar.bz2', 'zip']:
+        version = version.replace('.' + ext, '')
+    return version
+
+
 def get_file_hash(filename: str) -> str:
     sha = hashlib.sha256()
     print('Generating hash for', filename)
@@ -73,6 +92,13 @@ def get_file_hash(filename: str) -> str:
                 break
             sha.update(data)
         return sha.hexdigest()
+
+
+def download_tar_pypi(url: str, tempdir: str) -> None:
+    with urllib.request.urlopen(url) as response:
+        file_path = os.path.join(tempdir, url.split('/')[-1])
+        with open(file_path, 'x+b') as tar_file:
+            shutil.copyfileobj(response, tar_file)
 
 
 def parse_continuation_lines(fin):
@@ -144,23 +170,23 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         pip_download.append('--require-hashes')
 
     try:
-        # May download the package twice, the first time it allows pip to
-        # select the preferred package, if the package downloaded is not
-        # platform generic, then it forces pip to download the sdist (using
-        # the --no-binary option).
-
         subprocess.run(pip_download, check=True)
-        for filename in os.listdir(tempdir):
-            if not filename.endswith(('gz', 'any.whl', 'zip')):
-                os.remove(os.path.join(tempdir, filename))
-
-        subprocess.run(pip_download + [
-            '--no-binary', ':all:'
-            ], check=True)
-
     except subprocess.CalledProcessError:
         print('Failed to download')
         print('Please fix the module manually in the generated file')
+
+    for filename in os.listdir(tempdir):
+        if not filename.endswith(('gz', 'any.whl', 'zip')):
+            version = get_file_version(filename)
+            name = get_package_name(filename)
+            url = get_tar_package_url_pypi(name, version)
+            print('Deleting', filename)
+            try:
+                os.remove(os.path.join(tempdir, filename))
+            except FileNotFoundError:
+                pass
+            print('Downloading {}'.format(url))
+            download_tar_pypi(url, tempdir)
 
     files = {get_package_name(f): [] for f in os.listdir(tempdir)}
 
@@ -168,25 +194,20 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         name = get_package_name(filename)
         files[name].append(filename)
 
-    # Delete redundant sources, where .zip (vcs sources) take precedence
-    # over .whl, and .whl over tar.gz sources.
+    # Delete redundant sources, for vcs sources
     for name in files:
         if len(files[name]) > 1:
-            whl_source = False
             zip_source = False
             for f in files[name]:
-                if f.endswith(('any.whl')):
-                    whl_source = True
-                if f.endswith(('.zip')):
+                if f.endswith('.zip'):
                     zip_source = True
             if zip_source:
                 for f in files[name]:
-                    if not f.endswith(('.zip')):
-                        os.remove(os.path.join(tempdir, f))
-            elif whl_source:
-                for f in files[name]:
-                    if not f.endswith(('any.whl')):
-                        os.remove(os.path.join(tempdir, f))
+                    if not f.endswith('.zip'):
+                        try:
+                            os.remove(os.path.join(tempdir, f))
+                        except FileNotFoundError:
+                            pass
 
     vcs_packages = {
         x.name: {'vcs': x.vcs, 'revision': x.revision, 'uri': x.uri}

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -43,17 +43,19 @@ def get_pypi_url(name: str, filename: str) -> str:
             for source in release:
                 if source['filename'] == filename:
                     return source['url']
-        else:
-            raise Exception('Failed to extract url from {}'.format(url))
+        raise Exception('Failed to extract url from {}'.format(url))
 
 
 def get_tar_package_url_pypi(name: str, version: str) -> str:
     url = 'https://pypi.org/pypi/{}/{}/json'.format(name, version)
     with urllib.request.urlopen(url) as response:
         body = json.loads(response.read().decode('utf-8'))
-        for url in body['urls']:
-            if url['url'].endswith(('any.whl', 'gz', 'zip')):
-                return url['url']
+        for ext in ['any.whl', 'gz', 'zip']:
+            for source in body['urls']:
+                if source['url'].endswith(ext):
+                    return source['url']
+        err = 'Failed to get {}-{} source from {}'.format(name, version, url)
+        raise Exception(err)
 
 
 def get_package_name(filename: str) -> str:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -68,7 +68,11 @@ def get_package_name(filename: str) -> str:
         segments = filename.split('-')
         if len(segments) == 5:
             return segments[0]
-        return '-'.join(segments[:len(segments) - 4])
+        candidate = segments[:len(segments) - 4]
+        # Some packages list the version number twice
+        if candidate[-1] == segments[len(segments) - 4]:
+            return '-'.join(candidate[:-1])
+        return '-'.join(candidate)
     else:
         raise Exception(
             'Downloaded filename: {} does not end with bz2, gz, xz, zip, or whl'.format(filename)

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -84,7 +84,7 @@ def get_file_version(filename: str) -> str:
 
 def get_file_hash(filename: str) -> str:
     sha = hashlib.sha256()
-    print('Generating hash for', filename)
+    print('Generating hash for', filename.split('/')[-1])
     with open(filename, 'rb') as f:
         while True:
             data = f.read(1024 * 1024 * 32)
@@ -111,6 +111,34 @@ def parse_continuation_lines(fin):
                 exit('Requirements have a wrong number of line continuation characters "\\"')
         yield line
 
+
+def fprint(string: str) -> None:
+    separator = '=' * 72  # Same as `flatpak-builder`
+    print(separator)
+    print(string)
+    print(separator)
+
+
+if not opts.python2:
+    minor_version = str(sys.version_info[1])
+    command = [
+        'flatpak',
+        'run',
+        '--command=python3',
+        'org.freedesktop.Platform',
+        '--version'
+    ]
+    try:
+        result = subprocess.run(command, check=True, capture_output=True)
+        f_version = result.stdout.decode('utf-8')
+        f_minor_version = f_version.split('.')[1]
+        if minor_version != f_minor_version:
+            print('WARNING: the Python version on your host does not match the Python version in org.freedesktop.Platform')
+            print('host version: 3.{}, Freedesktop version: 3.{}'.format(minor_version, f_minor_version))
+            print('some packages are Python 3.{} specific'.format(f_minor_version))
+    except FileNotFoundError:
+        print('flatpak command not found')
+        print('Could not determine Python version of org.freedesktop.Platform')
 
 packages = []
 if opts.requirements_file and os.path.exists(opts.requirements_file):
@@ -169,12 +197,14 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
     if use_hash:
         pip_download.append('--require-hashes')
 
+    fprint('Downloading sources')
     try:
         subprocess.run(pip_download, check=True)
     except subprocess.CalledProcessError:
         print('Failed to download')
         print('Please fix the module manually in the generated file')
 
+    fprint('Downloading arch independent packages')
     for filename in os.listdir(tempdir):
         if not filename.endswith(('gz', 'any.whl', 'zip')):
             version = get_file_version(filename)
@@ -215,6 +245,7 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         if x.vcs
     }
 
+    fprint('Obtaining hashes and urls')
     for filename in os.listdir(tempdir):
         name = get_package_name(filename)
         sha256 = get_file_hash(os.path.join(tempdir, filename))
@@ -244,6 +275,8 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
 
 # Python3 packages that come as part of org.freedesktop.Sdk.
 system_packages = ['Mako', 'Markdown', 'meson', 'pip', 'setuptools', 'six']
+
+fprint('Generating dependencies')
 for package in packages:
 
     if package.name is None:
@@ -349,6 +382,7 @@ else:
         'modules': modules,
     }
 
+print()
 with open(output_filename, 'w') as output:
     output.write(json.dumps(pypi_module, indent=4))
     print('Output saved to {}'.format(output_filename))

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -49,7 +49,7 @@ def get_tar_package_url_pypi(name: str, version: str) -> str:
     url = 'https://pypi.org/pypi/{}/{}/json'.format(name, version)
     with urllib.request.urlopen(url) as response:
         body = json.loads(response.read().decode('utf-8'))
-        for ext in ['any.whl', 'gz', 'zip']:
+        for ext in ['gz', 'zip']:
             for source in body['urls']:
                 if source['url'].endswith(ext):
                     return source['url']


### PR DESCRIPTION
This pr eliminates the need to run `pip` with the `--no-binary` flag, this causes a great speedup in the process and greately reduces the ammount of data to download. Files which are arch dependent are redownloaded using the info in pypi.org. Solves #47, #131, #89, and #26. But doesn't address the fact that some `tar.gz` packages can't be just installed with `pip install`, such as `pyqt5`.

Bonus: The output was prettified significantly and a warning message will be show if the python version used is not the same as of org.freedesktop.Platform, packages as `qdarkstyle` would be downloaded specifically for the host python version.

**Whats left to do in a future PR:**

* Add a `--only-host-arch` flag to allow the use of, for example `*x86_64.whl` packages, this would fix most of all remaining issues if the flatpak is built only for one arch only.

* Consider adding `setuptools` and `wheel` to all sources. It is almost random which packages will need this, and they are quite a few. Some packages invoke `pip install --ignore-installed`.