### PR TITLE
pip: Run inside of a sandbox

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -158,6 +158,7 @@ else:
 if opts.runtime:
     flatpak_cmd = [
         'flatpak',
+        '--devel',
         '--share=network',
         '--filesystem=/tmp',
         '--command={}'.format(pip_executable),

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -35,7 +35,7 @@ parser.add_argument('--no-build-isolation',
 parser.add_argument('--output', '-o',
                     help='Specify output file name')
 parser.add_argument('--runtime',
-                    help='Specify a flatpak to run pip inside of a sandbox, ensures python version compatibility')
+                    help='Select a flatpak to run pip inside of a sandbox, ensures python version compatibility')
 opts = parser.parse_args()
 
 
@@ -150,27 +150,62 @@ with open(requirements_file, 'r') as req_file:
     use_hash = '--hash=' in req_file.read()
 
 python_version = '2' if opts.python2 else '3'
+# Prefer to use Sdk as they bundle `git`.
+possible_runtimes = [
+    'org.freedesktop.Sdk',
+    'org.freedesktop.Platform',
+    'org.gnome.Sdk',
+    'org.gnome.Platform',
+    'org.kde.Sdk',
+    'org.kde.Platform',
+    # If multiple branches are available, the script won't select any.
+    'org.freedesktop.Sdk//19.08',
+    'org.freedesktop.Platform//19.08',
+]
+if opts.runtime:
+    runtime = opts.runtime
+else:
+    for flatpak in possible_runtimes:
+        try:
+            flatpak_info = ['flatpak', 'info', '--show-runtime'] + [flatpak]
+            if subprocess.run(flatpak_info, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+                runtime = flatpak
+                break
+        except subprocess.CalledProcessError:
+            pass
+    else:
+        if not opts.requirements:
+            # The temporal requirements file is still around.
+            try:
+                os.remove(requirements_file)
+            except FileNotFoundError:
+                pass
+        print('No flatpak runtime could be found, try specifying a flatpak or runtime version')
+        exit('e.g. "flatpak-pip-generator --runtime domain.developer.app-id//branch [packages]"')
+
+    print('Using {} as a sandbox'.format(runtime))
+
 if opts.python2:
     pip_executable = 'pip2'
 else:
     pip_executable = 'pip3'
 
-if opts.runtime:
+if opts.python2 and not opts.runtime:
+    print('WARNING: --python2 requires a flatpak or runtime that bundles pip2 to be specified with --runtime for this script to be run inside a sandbox')
+    flatpak_cmd = [pip_executable]
+else:
     flatpak_cmd = [
         'flatpak',
-        '--devel',
         '--share=network',
         '--filesystem=/tmp',
         '--command={}'.format(pip_executable),
         'run',
-        opts.runtime
+        runtime
     ]
     if opts.requirements_file and os.path.exists(opts.requirements_file):
         prefix = os.path.realpath(opts.requirements_file)
         flag = '--filesystem={}'.format(prefix)
         flatpak_cmd.insert(1,flag)
-else:
-    flatpak_cmd = [pip_executable]
 
 if opts.output:
     output_package = opts.output
@@ -200,7 +235,6 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         '-r',
         requirements_file
     ]
-
     if use_hash:
         pip_download.append('--require-hashes')
 

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -34,6 +34,8 @@ parser.add_argument('--no-build-isolation',
                     help='https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support')
 parser.add_argument('--output', '-o',
                     help='Specify output file name')
+parser.add_argument('--runtime',
+                    help='Specify a flatpak to run pip inside of a sandbox, ensures python version compatibility')
 opts = parser.parse_args()
 
 
@@ -129,31 +131,6 @@ def fprint(string: str) -> None:
     print(separator)
 
 
-if not opts.python2:
-    minor_version = str(sys.version_info[1])
-    command = [
-        'flatpak',
-        'run',
-        '--command=python3',
-        'org.freedesktop.Platform',
-        '--version'
-    ]
-    try:
-        result = subprocess.run(command, check=True, capture_output=True)
-        f_version = result.stdout.decode('utf-8')
-        f_minor_version = f_version.split('.')[1]
-        if minor_version != f_minor_version:
-            print('WARNING: the Python version on your host does not match the Python version in org.freedesktop.Platform')
-            print('host version: 3.{}, Freedesktop version: 3.{}'.format(minor_version, f_minor_version))
-            print('some packages are Python 3.{} specific'.format(f_minor_version))
-    except FileNotFoundError:
-        print('flatpak command not found')
-        print('Could not determine Python version of org.freedesktop.Platform')
-        print('Verify that your python version coincides with the one in your flatpak runtime')
-    except subprocess.CalledProcessError:
-        print('Could not determine Python version of org.freedesktop.Platform')
-        print('Verify that your python version coincides with the one in your flatpak runtime')
-
 packages = []
 if opts.requirements_file and os.path.exists(opts.requirements_file):
     with open(opts.requirements_file, 'r') as req_file:
@@ -163,7 +140,7 @@ if opts.requirements_file and os.path.exists(opts.requirements_file):
         requirements_file = opts.requirements_file
 elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))
-    with tempfile.NamedTemporaryFile('w', delete=False) as req_file:
+    with tempfile.NamedTemporaryFile('w', delete=False, prefix='requirements.') as req_file:
         req_file.write('\n'.join(opts.packages))
         requirements_file = req_file.name
 else:
@@ -177,6 +154,23 @@ if opts.python2:
     pip_executable = 'pip2'
 else:
     pip_executable = 'pip3'
+
+if opts.runtime:
+    flatpak_cmd = [
+        'flatpak',
+        '--devel',
+        '--share=network',
+        '--filesystem=/tmp',
+        '--command={}'.format(pip_executable),
+        'run',
+        opts.runtime
+    ]
+    if opts.requirements_file and os.path.exists(opts.requirements_file):
+        prefix = os.path.realpath(opts.requirements_file)
+        flag = '--filesystem={}'.format(prefix)
+        flatpak_cmd.insert(1,flag)
+else:
+    flatpak_cmd = [pip_executable]
 
 if opts.output:
     output_package = opts.output
@@ -198,8 +192,7 @@ sources = {}
 
 tempdir_prefix = 'pip-generator-{}'.format(output_filename.replace('.json', ''))
 with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
-    pip_download = [
-        pip_executable,
+    pip_download = flatpak_cmd + [
         'download',
         '--exists-action=i',
         '--dest',
@@ -212,11 +205,19 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         pip_download.append('--require-hashes')
 
     fprint('Downloading sources')
+    cmd = ' '.join(pip_download)
+    print('Running: "{}"'.format(cmd))
     try:
         subprocess.run(pip_download, check=True)
     except subprocess.CalledProcessError:
         print('Failed to download')
         print('Please fix the module manually in the generated file')
+
+    if not opts.requirements_file:
+        try:
+            os.remove(requirements_file)
+        except FileNotFoundError:
+            pass
 
     fprint('Downloading arch independent packages')
     for filename in os.listdir(tempdir):
@@ -320,9 +321,8 @@ for package in packages:
     # Downloads the package again to list dependencies
 
     tempdir_prefix = 'pip-generator-{}'.format(package.name)
-    with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
-        pip_download = [
-            pip_executable,
+    with tempfile.TemporaryDirectory(prefix='{}-{}'.format(tempdir_prefix, package.name)) as tempdir:
+        pip_download = flatpak_cmd + [
             'download',
             '--exists-action=i',
             '--dest',
@@ -378,12 +378,6 @@ for package in packages:
         vcs_modules.append(module)
     else:
         modules.append(module)
-
-if not opts.requirements_file:
-    try:
-        os.remove(requirements_file)
-    except FileNotFoundError:
-        pass
 
 modules = vcs_modules + modules
 if len(modules) == 1:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -191,7 +191,7 @@ else:
     pip_executable = 'pip3'
 
 if opts.python2 and not opts.runtime:
-    print('WARNING: --python2 requires a flatpak or runtime that bundles pip2 to be specified with --runtime for this script to be run inside a sandbox')
+    print('Warning: --python2 requires a flatpak app that bundles pip2 to be specified with --runtime for this script to be run inside a sandbox')
     flatpak_cmd = [pip_executable]
 else:
     flatpak_cmd = [

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -35,7 +35,7 @@ parser.add_argument('--no-build-isolation',
 parser.add_argument('--output', '-o',
                     help='Specify output file name')
 parser.add_argument('--runtime',
-                    help='Select a flatpak to run pip inside of a sandbox, ensures python version compatibility')
+                    help='Specify a flatpak to run pip inside of a sandbox, ensures python version compatibility')
 opts = parser.parse_args()
 
 
@@ -150,62 +150,26 @@ with open(requirements_file, 'r') as req_file:
     use_hash = '--hash=' in req_file.read()
 
 python_version = '2' if opts.python2 else '3'
-# Prefer to use Sdk as they bundle `git`.
-possible_runtimes = [
-    'org.freedesktop.Sdk',
-    'org.freedesktop.Platform',
-    'org.gnome.Sdk',
-    'org.gnome.Platform',
-    'org.kde.Sdk',
-    'org.kde.Platform',
-    # If multiple branches are available, the script won't select any.
-    'org.freedesktop.Sdk//19.08',
-    'org.freedesktop.Platform//19.08',
-]
-if opts.runtime:
-    runtime = opts.runtime
-else:
-    for flatpak in possible_runtimes:
-        try:
-            flatpak_info = ['flatpak', 'info', '--show-runtime'] + [flatpak]
-            if subprocess.run(flatpak_info, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
-                runtime = flatpak
-                break
-        except subprocess.CalledProcessError:
-            pass
-    else:
-        if not opts.requirements:
-            # The temporal requirements file is still around.
-            try:
-                os.remove(requirements_file)
-            except FileNotFoundError:
-                pass
-        print('No flatpak runtime could be found, try specifying a flatpak or runtime version')
-        exit('e.g. "flatpak-pip-generator --runtime domain.developer.app-id//branch [packages]"')
-
-    print('Using {} as a sandbox'.format(runtime))
-
 if opts.python2:
     pip_executable = 'pip2'
 else:
     pip_executable = 'pip3'
 
-if opts.python2 and not opts.runtime:
-    print('Warning: --python2 requires a flatpak app that bundles pip2 to be specified with --runtime for this script to be run inside a sandbox')
-    flatpak_cmd = [pip_executable]
-else:
+if opts.runtime:
     flatpak_cmd = [
         'flatpak',
         '--share=network',
         '--filesystem=/tmp',
         '--command={}'.format(pip_executable),
         'run',
-        runtime
+        opts.runtime
     ]
     if opts.requirements_file and os.path.exists(opts.requirements_file):
         prefix = os.path.realpath(opts.requirements_file)
         flag = '--filesystem={}'.format(prefix)
         flatpak_cmd.insert(1,flag)
+else:
+    flatpak_cmd = [pip_executable]
 
 if opts.output:
     output_package = opts.output


### PR DESCRIPTION
* For Python 3 packages it will run in the first runtime or sdk that it is available, running without a sandbox is not an option.

* Python 2 packages will use the host's `pip2` command unless a flatpak which bundles pip2 is specified. The is no natural choice flatpak the user should use as a default.

* The temporal requirements file is deleted as soon as it is not needed anymore.