### PR TITLE
node: Support for Yarn git packages

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1391,10 +1391,11 @@ class YarnModuleProvider(ModuleProvider):
             self.gen.add_url_source(source.resolved, integrity, self.mirror_dir / filename)
 
         elif isinstance(source, GitSource):
+            repo_name = urllib.parse.urlparse(source.url).path.split('/')[-1]
             tarball_url = source.tarball_url
             assert tarball_url is not None
             metadata = await RemoteUrlMetadata.get(tarball_url, cachable=True)
-            filename = f'{package.name}.git-{source.commit}'
+            filename = f'{repo_name}-{source.commit}'
 
             #XXX Yarn wants uncompressed tar, why?
             self.gen.add_url_source(tarball_url, metadata.integrity, self.mirror_dir / f'{filename}.gz')

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -30,7 +30,7 @@ import urllib.request
 
 DEFAULT_PART_SIZE = 4096
 
-GIT_SCHEMES = {
+GIT_SCHEMES: Dict[str, Dict[str, str]] = {
     'github': {'scheme': 'https', 'netloc': 'github.com'},
     'gitlab': {'scheme': 'https', 'netloc': 'gitlab.com'},
     'bitbucket': {'scheme': 'https', 'netloc': 'bitbucket.com'},

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -484,7 +484,7 @@ class GitSource(NamedTuple):
     original: str
     url: str
     commit: str
-    from_: str
+    from_: Optional[str]
 
 
 PackageSource = Union[ResolvedSource, UnresolvedRegistrySource, GitSource]
@@ -1206,6 +1206,7 @@ class NpmModuleProvider(ModuleProvider):
                 for path, source in sources.items():
                     original_version = f'{source.original}#{source.commit}'
                     new_version = f'{path}#{source.commit}'
+                    assert source.from_ is not None
                     data['package.json'][source.from_] = new_version
                     data['package-lock.json'][original_version] = new_version
 


### PR DESCRIPTION
Yarn mirrors git packages as uncompressed tarballs named after the  source repo and commit hash. I'm not quite sure if it's always the case, but it seems to be so for at least 1.22+