### PR TITLE
node: handle empty dependencies

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1039,7 +1039,7 @@ class NpmLockfileProvider(LockfileProvider):
 
         assert data['lockfileVersion'] == 1, data['lockfileVersion']
 
-        yield from self.process_dependencies(lockfile, data['dependencies'])
+        yield from self.process_dependencies(lockfile, data.get('dependencies', {}))
 
 
 class NpmModuleProvider(ModuleProvider):


### PR DESCRIPTION
This change allows empty dependency declarations such as the one found
here: https://github.com/laurent22/joplin/blob/20bec7e26c175bc3fcd43be4c1a6c016c14a5fc8/Clipper/package.json

Passing the empty list should be semantically equivalent to no
dependencies.

It's probably not very common that a module doesn't have any dependencies... But I do wonder whether I am the first person to encounter empty dependencies.