### PR TITLE
node: Fix git source url for npm

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -660,14 +660,12 @@ class LockfileProvider:
         assert original_url.scheme and original_url.path and original_url.fragment
         assert original_url.scheme in GIT_SCHEMES, f'{version} doesn\'t match any Git prefix'
 
-        print(f'Original URL: {original_url.geturl()}')
         replacements = GIT_SCHEMES[original_url.scheme]
         new_url = original_url._replace(fragment='', **replacements)
         # Replace e.g. git:github.com/owner/repo with git://github.com/owner/repo
         if not new_url.netloc:
             path = new_url.path.split('/')
             new_url = new_url._replace(netloc=path[0], path='/'.join(path[1:]))
-        print(f'Replaced URL: {new_url.geturl()}')
 
         return GitSource(original=original_url.geturl(),
                          url=new_url.geturl(),

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -662,7 +662,7 @@ class LockfileProvider:
         if original_url.scheme in GIT_SCHEMES:
             replacements = GIT_SCHEMES[original_url.scheme]
             print(f'Original URL: {original_url.geturl()}')
-            new_url = original_url._replace(**replacements)
+            new_url = original_url._replace(fragment='', **replacements)
             # Replace e.g. git:github.com/owner/repo with git://github.com/owner/repo
             if not new_url.netloc:
                 path = new_url.path.split('/')

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -658,18 +658,16 @@ class LockfileProvider:
     def parse_git_source(self, version: str, from_: str = None) -> GitSource:
         original_url = urllib.parse.urlparse(version)
         assert original_url.scheme and original_url.path and original_url.fragment
+        assert original_url.scheme in GIT_SCHEMES, f'{version} doesn\'t match any Git prefix'
 
-        if original_url.scheme in GIT_SCHEMES:
-            replacements = GIT_SCHEMES[original_url.scheme]
-            print(f'Original URL: {original_url.geturl()}')
-            new_url = original_url._replace(fragment='', **replacements)
-            # Replace e.g. git:github.com/owner/repo with git://github.com/owner/repo
-            if not new_url.netloc:
-                path = new_url.path.split('/')
-                new_url = new_url._replace(netloc=path[0], path='/'.join(path[1:]))
-            print(f'Replaced URL: {new_url.geturl()}')
-        else:
-            raise ValueError(f'{version} doesn\'t match any Git prefix')
+        print(f'Original URL: {original_url.geturl()}')
+        replacements = GIT_SCHEMES[original_url.scheme]
+        new_url = original_url._replace(fragment='', **replacements)
+        # Replace e.g. git:github.com/owner/repo with git://github.com/owner/repo
+        if not new_url.netloc:
+            path = new_url.path.split('/')
+            new_url = new_url._replace(netloc=path[0], path='/'.join(path[1:]))
+        print(f'Replaced URL: {new_url.geturl()}')
 
         return GitSource(original=original_url.geturl(),
                          url=new_url.geturl(),


### PR DESCRIPTION
It appears that #144 broke git dependencies for npm by passing url with fragment to flatpak-builder.
fb2a0a7 restores previous behavior by removing the fragment from url.
Should fix #152 