### PR TITLE
[node] Generate our own tarball

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1385,10 +1385,10 @@ class YarnModuleProvider(ModuleProvider):
 
         elif isinstance(source, GitSource):
             repo_name = urllib.parse.urlparse(source.url).path.split('/')[-1]
-            repo_dir = self.gen.tmp_root / repo_name
-            target_tar = self.mirror_dir / f'{repo_name}-{source.commit}'
+            name = f'{repo_name}-{source.commit}'
+            repo_dir = self.gen.tmp_root / name
+            target_tar = self.mirror_dir / name
 
-            #XXX Yarn wants uncompressed tar, why?
             self.gen.add_git_source(source.url, source.commit, repo_dir)
             self.gen.add_command(f'cd {repo_dir}; git archive --format tar -o ../../../{target_tar} HEAD')
 

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1387,10 +1387,10 @@ class YarnModuleProvider(ModuleProvider):
             repo_name = urllib.parse.urlparse(source.url).path.split('/')[-1]
             name = f'{repo_name}-{source.commit}'
             repo_dir = self.gen.tmp_root / name
-            target_tar = self.mirror_dir / name
+            target_tar = os.path.relpath(self.mirror_dir / name, repo_dir)
 
             self.gen.add_git_source(source.url, source.commit, repo_dir)
-            self.gen.add_command(f'cd {repo_dir}; git archive --format tar -o ../../../{target_tar} HEAD')
+            self.gen.add_command(f'cd {repo_dir}; git archive --format tar -o {target_tar} HEAD')
 
         await self.special_source_provider.generate_special_sources(package)
 


### PR DESCRIPTION
And stop relying on the ones generated by a git hosting provider.

Reason is that at least Github generates tarball with a root directory in the form of repo_name-commit_id/ which gets decompressed as is in node_modules by Yarn.
It is incompatible with webpack's resolver that expects a flat directory structure in node_modules.