### PR TITLE
cpan: Enable support for proxies when fetching archives

### DIFF
--- a/cpan/flatpak-cpan-generator.pl
+++ b/cpan/flatpak-cpan-generator.pl
@@ -32,6 +32,7 @@ sub get_url_sha256 {
 
   my $state = Digest::SHA->new(256);
   my $ua = LWP::UserAgent->new;
+  $ua->env_proxy;
 
   my $resp = $ua->get($url, ':read_size_hint' => 1024,
                       ':content_cb' => sub {


### PR DESCRIPTION
This makes flatpak-cpan-generator.pl pick up, e.g., http_proxy and
https_proxy variables from the environment, allowing it to fetch
archives through a firewall.