### PR TITLE
cpan: Correct parsing of output from cpanminus

### DIFF
--- a/cpan/flatpak-cpan-generator.pl
+++ b/cpan/flatpak-cpan-generator.pl
@@ -21,7 +21,7 @@ sub scan_deps {
 
   for (@deps)
   {
-      s/^Successfully installed (.*)/$1/;
+      s/^Successfully installed (\S+).*/$1/;
   }
 
    @deps


### PR DESCRIPTION
cpanminus may output information about up/downgrading of modules it
installs, e.g.:

  Successfully installed PathTools-3.75 (upgraded from 3.74)

Correct the regular expression matching the installed packages so only
the name is matched.