### PR TITLE
pip: fix some edge cases in dependency to source mapping

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -337,11 +337,19 @@ for package in packages:
             print('Failed to download {}'.format(package.name))
 
     is_vcs = True if package.vcs else False
-    package_sources = [sources[x]['source']
-                       for x in dependencies
-                       if x in sources
-                       # Add vcs source only if package is vcs
-                       and (not sources[x]['vcs'] or is_vcs)]
+    package_sources = []
+    for dependency in dependencies:
+        if dependency in sources:
+            source = sources[dependency]
+        elif dependency.replace('_', '-') in sources:
+            source = sources[dependency.replace('_', '-')]
+        else:
+            continue
+
+        if not (not source['vcs'] or is_vcs):
+            continue
+
+        package_sources.append(source['source'])
 
     if package.vcs:
         name_for_pip = '.'


### PR DESCRIPTION
pip doesn't seem to make a difference betweek `-` and `_`

For example for flake8-bugbear, the source package name is flake8_bugbear, which causes it to be skipped when constructing the source map

but you also have setuptools_scm, for which the source name is the same as the package name.