### PR TITLE
pip: always build from source tarball (discarding wheel file)

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -55,7 +55,7 @@ def get_tar_package_url_pypi(name: str, version: str) -> str:
     url = 'https://pypi.org/pypi/{}/{}/json'.format(name, version)
     with urllib.request.urlopen(url) as response:
         body = json.loads(response.read().decode('utf-8'))
-        for ext in ['gz', 'zip']:
+        for ext in ['bz2', 'gz', 'xz', 'zip']:
             for source in body['urls']:
                 if source['url'].endswith(ext):
                     return source['url']
@@ -220,7 +220,7 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
 
     fprint('Downloading arch independent packages')
     for filename in os.listdir(tempdir):
-        if not filename.endswith(('gz', 'any.whl', 'zip')):
+        if not filename.endswith(('bz2', 'gz', 'xz', 'zip')):
             version = get_file_version(filename)
             name = get_package_name(filename)
             url = get_tar_package_url_pypi(name, version)


### PR DESCRIPTION
Also support more tarball types