### PR TITLE
Reverse build isolation switch

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -30,8 +30,13 @@ parser.add_argument('--requirements-file', '-r',
 parser.add_argument('--build-only', action='store_const',
                     dest='cleanup', const='all',
                     help='Clean up all files after build')
-parser.add_argument('--no-build-isolation', action='store_true', default=False,
-                    help='https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support')
+parser.add_argument('--build-isolation', action='store_true',
+                    default=False,
+                    help=(
+                        'Do not disable build isolation. '
+                        'Mostly useful on pip that does\'t '
+                        'support the feature.'
+                    )
 parser.add_argument('--output', '-o',
                     help='Specify output file name')
 parser.add_argument('--runtime',
@@ -370,7 +375,7 @@ for package in packages:
         '--prefix=${FLATPAK_DEST}',
         '"{}"'.format(name_for_pip)
     ]
-    if opts.no_build_isolation:
+    if not opts.build_isolation:
         pip_command.append('--no-build-isolation')
 
     module = OrderedDict([


### PR DESCRIPTION
The reasonable default in pip that supports build isolation is to disable it. Fixes #157