### PR TITLE
node: Fix npm git patch

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1205,7 +1205,7 @@ class NpmModuleProvider(ModuleProvider):
                         then
                             if (.version | type == "string") and $data[.version]
                             then
-                                .version = "git+file:\($buildroot)/\($data[.version])"
+                                .version = "git+file:\($buildroot)/\($data[.version])" | .from = .version
                             elif (.requires | type == "object")
                             then
                                 .requires = (.requires | with_entries(

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1231,10 +1231,11 @@ class NpmModuleProvider(ModuleProvider):
                 }
 
                 for path, source in sources.items():
-                    original_version = f'{source.original}#{source.commit}'
+                    original_version = f'{source.original}'
                     new_version = f'{path}#{source.commit}'
                     assert source.from_ is not None
                     data['package.json'][source.from_] = new_version
+                    data['package-lock.json'][source.from_] = new_version
                     data['package-lock.json'][original_version] = new_version
 
                 for filename, script in scripts.items():

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1201,9 +1201,22 @@ class NpmModuleProvider(ModuleProvider):
                 'package-lock.json':
                     '''
                     walk(
-                        if type == "object" and (.version | type == "string") and $data[.version]
+                        if type == "object"
                         then
-                            .version = "git+file:\($buildroot)/\($data[.version])"
+                            if (.version | type == "string") and $data[.version]
+                            then
+                                .version = "git+file:\($buildroot)/\($data[.version])"
+                            elif (.requires | type == "object")
+                            then
+                                .requires = (.requires | with_entries(
+                                    if (.value | type == "string") and $data[.value]
+                                    then
+                                        .value = "git+file:\($buildroot)/\($data[.value])"
+                                    else .
+                                    end
+                                ))
+                            else .
+                            end
                         else .
                         end
                     )


### PR DESCRIPTION
lockfile code
```json
    "tkwidgets": {
      "version": "0.5.26",
      "resolved": "https://registry.npmjs.org/tkwidgets/-/tkwidgets-0.5.26.tgz",
      "integrity": "sha512-zxhwsBpxD5fglnqHYZ9ZjunC8Hc67u/7QXzxHmhAIzzSr4a/Cq5PbzCeHsBZ7WL99uBUa6xgVLfjmGxnFU8XMg==",
      "requires": {
        "chalk": "^2.1.0",
        "emphasize": "^1.5.0",
        "node-emoji": "git+https://github.com/laurent22/node-emoji.git",
        "slice-ansi": "^1.0.0",
        "string-width": "^2.1.1",
        "terminal-kit": "^1.13.11",
        "wrap-ansi": "^3.0.1"
      },
      "dependencies": {
        "chalk": {
          "version": "2.4.2",
          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
          "requires": {
            "ansi-styles": "^3.2.1",
            "escape-string-regexp": "^1.0.5",
            "supports-color": "^5.3.0"
          }
        },
        "node-emoji": {
          "version": "git+https://github.com/laurent22/node-emoji.git#9fa01eac463e94dde1316ef8c53089eeef4973b5",
          "from": "git+https://github.com/laurent22/node-emoji.git",
          "requires": {
            "lodash.toarray": "^4.4.0"
          }
        }
      }
    }
```

There is a git url in requires, `"node-emoji": "git+https://github.com/laurent22/node-emoji.git",`  need replace too.  
Don't know if this is standard behavior, as package.json don't have git url, 
above code come from https://github.com/laurent22/joplin/blob/dev/packages/app-cli/package-lock.json