### PR TITLE
node: Add option to symlink SDK node headers

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -69,6 +69,7 @@ optional arguments:
                         Download the ffmpeg binaries
   --electron-node-headers
                         Download the electron node headers
+  --xdg-layout          Use XDG layout for caches
 ```
 
 flatpak-node-generator.py takes the package manager (npm or yarn), and a path to a lockfile for

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1658,6 +1658,21 @@ async def main() -> None:
             with GeneratorProgress(packages, module_provider) as progress:
                 await progress.run()
 
+        if args.xdg_layout:
+            script_name = "setup_sdk_node_headers.sh"
+            node_gyp_dir = gen.data_root / "cache" / "node-gyp"
+            gen.add_script_source(
+                [   
+                    'version=$(node --version | sed "s/^v//")',
+                    'nodedir=$(dirname "$(dirname "$(which node)")")',
+                    f'mkdir -p "{node_gyp_dir}/$version"',
+                    f'ln -s "$nodedir/include" "{node_gyp_dir}/$version/include"',
+                    f'echo 9 > "{node_gyp_dir}/$version/installVersion"',
+                ],
+                destination=gen.data_root / script_name
+            )
+            gen.add_command(f"bash {gen.data_root / script_name}")
+
     if args.split:
         for i, part in enumerate(gen.split_sources()):
             output = Path(args.output)


### PR DESCRIPTION
This is needed in cases when native modules wirh node (not electron) ABI are required at build time (e.g. for node-sass) and setting `npm_config_nodedir` isn't enough.

Here we just symlink `/usr/lib/sdk/nodeN/include` to `flatpak-node/cache/node-gyp/VERSION/include`. Such script could be added manually, but I believe it would be more convinient if the generator handles it.