### PR TITLE
node: Support having multiple generated sources

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1325,7 +1325,7 @@ class NpmModuleProvider(ModuleProvider):
             index_commands.append(f'os.chdir({str(self.cacache_dir)!r})')
 
             for parent in sorted(parents, key=len):
-                index_commands.append(f'os.mkdir({parent!r})')
+                index_commands.append(f'os.makedirs({parent!r}, exist_ok=True)')
 
             for path, entry in self.index_entries.items():
                 path = path.relative_to(self.cacache_dir)


### PR DESCRIPTION
In some cases apps have different components/modules in the same
repository, and thus the flatpak for them would need several generated
node sources. However, if we try to use both generated sources in the
same flatpak module, they'd fail because we'd try to create directories
(index-v5 and hash-prefixes) that may exist.

Thus, in order to support using multiple generated sources, this patch
makes the generated sources be tolerant to the existence of the
mentioned folders.