### PR TITLE
pip: add verbose flag to install command

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -369,6 +369,7 @@ for package in packages:
     pip_command = [
         pip_executable,
         'install',
+        '--verbose',
         '--exists-action=i',
         '--no-index',
         '--find-links="file://${PWD}"',


### PR DESCRIPTION
better to have some logs than a spin wheel that doesn't even work on flathub build system.

I also had the impression that it slightly improves build time, but I don't have any number to support this.