### PR TITLE
node: Support lockfile v2

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1070,7 +1070,7 @@ class NpmLockfileProvider(LockfileProvider):
         with open(lockfile) as fp:
             data = json.load(fp)
 
-        assert data['lockfileVersion'] == 1, data['lockfileVersion']
+        assert data['lockfileVersion'] <= 2, data['lockfileVersion']
 
         yield from self.process_dependencies(lockfile, data.get('dependencies', {}))
 


### PR DESCRIPTION
Since v2 is backwards compatible with v1, this seems to be all that's
needed to support lockfile v2.

Closes: #192