### PR TITLE
cpan: Don't put slashes in dest-filename

### DIFF
--- a/cpan/flatpak-cpan-generator.pl
+++ b/cpan/flatpak-cpan-generator.pl
@@ -114,7 +114,8 @@ sub main {
 
   push @sources, {
     type => 'script',
-    'dest-filename' => "@{[$opts->dir]}/install.sh",
+    dest => $opts->dir,
+    'dest-filename' => 'install.sh',
     commands => [
       "set -e",
       "function make_install {",


### PR DESCRIPTION
Recent versions of flatpak-builder will reject this, causing build failures.