### PR TITLE
node: Add NW.js support

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -237,3 +237,20 @@ use to overwrite the default Electron ffmpeg, e.g.:
 ```
 
 An short example of this is again in the electron-webpack-quick-start
+
+## NW.js
+
+This scripts assumes NW.js is used if the lockfile contains `nw-builder` package.
+
+### Specifying NW.js version
+
+Unlike Electron, NW.js engine version is not reflected in NPM package.
+
+- If the app you're building uses specific NW.js version, specify it
+  using `--nwjs-version` argument
+- If any NW.js version will suffice, this script will use latest;
+  the version number will be stored in `flatpak-node/nwjs-version` file.
+  You can tell `nw-builder` to use this version by passing `-v` arg to `nwbuild`:
+  ```bash
+  nwbuild -v $(<$FLATPAK_BUILDER_BUILDDIR/flatpak-node/nwjs-version)
+  ```

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -688,7 +688,7 @@ class LockfileProvider:
         raise NotImplementedError()
 
 
-class ModuleProvider(contextlib.AbstractContextManager['ModuleProvider']):
+class ModuleProvider(contextlib.AbstractContextManager):
     async def generate_package(self, package: Package) -> None:
         raise NotImplementedError()
 
@@ -1540,7 +1540,7 @@ class YarnProviderFactory(ProviderFactory):
         return YarnModuleProvider(gen, special)
 
 
-class GeneratorProgress(contextlib.AbstractContextManager['GeneratorProgress']):
+class GeneratorProgress(contextlib.AbstractContextManager):
     def __init__(self, packages: Collection[Package],
                  module_provider: ModuleProvider) -> None:
         self.finished = 0


### PR DESCRIPTION
NW.js itself isn't stored in the lockfile (as far as I can tell), thus trigger NW.js source addition if the lockfile has `nw-builder` package - the most commonly used one to build NW.js apps.

I don't know a generic way to determine used NW.js version from well-known files, thus the NW.js version has to be passed on CLI via the new `--nw-version` option.

Unlike `electron/get`, `nw-builder` download cache can be stored anywhere (by default in the `cache/` subdir of the project), thus we download it to `flatpak-node/nwjs-cache/` dir, which should be symlinked manually to a proper path.

node-headers and 3rd-party ffmpeg are added for completeness, I'm not sure if these are useful in real projects.