### PR TITLE
Adding missing GOPATH env variable to example

### DIFF
--- a/go-get/README.md
+++ b/go-get/README.md
@@ -13,7 +13,8 @@ The script does not require Go in the host system.
   "buildsystem": "simple",
   "build-options": {
     "env": {
-      "GOBIN": "/app/bin/"
+      "GOBIN": "/app/bin/",
+      "GOPATH": "/run/build/writeas-cli"
     },
     "build-args": [
       "--share=network"

--- a/go-get/README.md
+++ b/go-get/README.md
@@ -11,10 +11,11 @@ The script does not require Go in the host system.
 {
   "name": "writeas-cli",
   "buildsystem": "simple",
+  "builddir": true,
   "build-options": {
     "env": {
       "GOBIN": "/app/bin/",
-      "GOPATH": "/run/build/writeas-cli"
+      "GOPATH": "/run/build/writeas-cli/_flatpak_build"
     },
     "build-args": [
       "--share=network"


### PR DESCRIPTION
At least from what I understand, it should be set like this as mentioned in the text above.