### PR TITLE
remove depricated asyncio call

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1846,4 +1846,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
in python 3.10rc1 a deprecation warning is given for `asyncio.get_event_loop()` since there is no current event loop. instead a better way of starting a async block from synchronous code is to use `asyncio.run(function(args))` 