### PR TITLE
switch to semver over distutils

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -9,7 +9,7 @@ from typing import *  # pyright: reportWildcardImportFromLibrary=false
 from typing import cast, IO
 
 from pathlib import Path
-from distutils.version import StrictVersion
+from semver import VersionInfo
 
 import argparse
 import asyncio
@@ -850,7 +850,7 @@ class SpecialSourceProvider:
 
     def _handle_gulp_atom_electron(self, package: Package) -> None:
         # Versions after 1.22.0 use @electron/get and don't need this
-        if StrictVersion(package.version) <= StrictVersion('1.22.0'):
+        if VersionInfo.parse(package.version) <= VersionInfo.parse('1.22.0'):
             cache_path = self.gen.data_root / 'tmp' / 'gulp-electron-cache' / 'atom' / 'electron'
             self.gen.add_command(f'mkdir -p "{cache_path.parent}"')
             self.gen.add_command(f'ln -sfTr "{self.electron_cache_dir}" "{cache_path}"')

--- a/node/requirements.txt
+++ b/node/requirements.txt
@@ -1,0 +1,10 @@
+aiohttp==3.7.4.post0
+async-timeout==3.0.1
+attrs==21.2.0
+chardet==4.0.0
+idna==3.3
+multidict==5.2.0
+requirements-parser==0.2.0
+semver==2.13.0
+typing-extensions==3.10.0.2
+yarl==1.7.0


### PR DESCRIPTION
distutils is depreciated, PEP 632 recommends using `packaging` instead of `distultis.version`.  