### PR TITLE
node: Fix npm git patch url match

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1374,7 +1374,7 @@ class NpmModuleProvider(ModuleProvider):
                 }
 
                 for path, source in sources.items():
-                    original_version = f'{source.original}#{source.commit}'
+                    original_version = f'{source.original}'
                     new_version = f'{path}#{source.commit}'
                     assert source.from_ is not None
                     data['package.json'][source.from_] = new_version


### PR DESCRIPTION
```python
>>> import urllib.parse
>>> original_url = urllib.parse.urlparse("git+ssh://git@github.com/bengotow/slate-edit-list.git#b868e1088b44ad1adb2cb06bbbb847a2fef7edb5")
>>> original=original_url.geturl()
>>> commit=original_url.fragment
>>> original
'git+ssh://git@github.com/bengotow/slate-edit-list.git#b868e1088b44ad1adb2cb06bbbb847a2fef7edb5'
>>> original_version = f'{original}#{commit}'
>>> original_version
'git+ssh://git@github.com/bengotow/slate-edit-list.git#b868e1088b44ad1adb2cb06bbbb847a2fef7edb5#b868e1088b44ad1adb2cb06bbbb847a2fef7edb5'
```
`f'{source.original}#{source.commit}'` is wrong.  
