### PR TITLE
node: Fix npm git patch from_ match

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1377,7 +1377,8 @@ class NpmModuleProvider(ModuleProvider):
                     original_version = f'{source.original}'
                     new_version = f'{path}#{source.commit}'
                     assert source.from_ is not None
-                    data['package.json'][source.from_] = new_version
+                    from_ = re.sub(r'^[^@]+@git\+', 'git+', source.from_)
+                    data['package.json'][from_] = new_version
                     data['package-lock.json'][original_version] = new_version
 
                 for filename, script in scripts.items():


### PR DESCRIPTION
From [npm-package-arg](https://github.com/npm/npm-package-arg#result-object), the `result.raw` may be `name + '@' + spec`.
In my test, I get:  
```text
package-lock.json:
npm6 : github:npm/hosted-git-info
npm7+: hosted-git-info@github:npm/hosted-git-info

package.json:
github:npm/hosted-git-info
```

From https://github.com/npm/arborist/blob/d9c603ede4fefb0bda1385e70b431b3adec810bf/lib/shrinkwrap.js#L961-L973
the `lock.from` normally be assigned `npa.resolve(node.name, edge.spec, edge.from.realpath).raw`

Just use regex to remove `name@` before real spec in `from_`,  as the `package.json` will not be like this.  