### PR TITLE
node: Fix non tgz index_entry not valied on npm 8 by adding reqHeaders

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -66,6 +66,7 @@ GIT_URL_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.com', 'bitbucket.org']
 
 NPM_MIRROR = 'https://unpkg.com/'
 
+NPM_CORGIDOC = 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
 
 class Cache:
     instance: 'Cache'
@@ -1220,6 +1221,7 @@ class NpmModuleProvider(ModuleProvider):
 
     def add_index_entry(self, url: str, metadata: RemoteUrlMetadata) -> None:
         key = f'make-fetch-happen:request-cache:{url}'
+        reqH = {} if url[-4:] == '.tgz' else { 'accept': NPM_CORGIDOC }
         index_json = json.dumps({
             'key':
                 key,
@@ -1231,7 +1233,7 @@ class NpmModuleProvider(ModuleProvider):
                 metadata.size,
             'metadata': {
                 'url': url,
-                'reqHeaders': {},
+                'reqHeaders': reqH,
                 'resHeaders': {},
             },
         })


### PR DESCRIPTION
Currently, there are two kinds of cacache key in npm.  
tgz key: `make-fetch-happen:request-cache:https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz`  
non tgz key: `make-fetch-happen:request-cache:https://registry.npmjs.org/node-emoji`  

From https://github.com/npm/pacote/blob/bd67be1ea53ab02c2be781a3fc2283eb9fcba3c8/lib/fetcher.js#L282-L327  
There are two func `fromCache` and `fromResolved`, the unresolved will go `fromResolved`.  
It will go through resolve() -> manifest() -> packument() -> fetch(packumentUr)  
The `packumentUrl` actually is like `https://registry.npmjs.org/node-emoji`  
This fetch func will query cacache content by non tgz key, do some checks, and will do real network fetch if check failed.  

From https://github.com/npm/make-fetch-happen/blob/ff3d03c7828bb029de556c5df1714e30c173c81e/lib/cache/policy.js#L95-L116
The fetch func will compare two request, one is the `reqHeaders` in index_entry(this pr changed),  other is generated by code  
And It will get false on (other header filed are not used)
```js
if (JSON.stringify(negotiatorA.mediaTypes()) !== JSON.stringify(negotiatorB.mediaTypes()))
      return false
```
```js
Negotiator.prototype.mediaTypes = function mediaTypes(available) {
  var preferredMediaTypes = loadModule('mediaType').preferredMediaTypes;
  return preferredMediaTypes(this.request.headers.accept, available);
};
```

From https://github.com/npm/pacote/blob/bd67be1ea53ab02c2be781a3fc2283eb9fcba3c8/lib/registry.js#L63-L74  
We know that `this.request.headers.accept` is ` this.fullMetadata ? fullDoc : corgiDoc`  

I just copy the value of `corgiDoc` to the code, and change the `reqHeaders` if get non tgz index_tgz.  