### PR TITLE
node: Use inline type source to embed data

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -5,6 +5,7 @@ A more modern successor for flatpak-npm-generator and flatpak-yarn-generator, fo
 
 ## Requirements
 
+- flatpak-builder 1.1.2 or newer
 - Python 3.6+.
 - aiohttp. (flatpak-node-generator will fall back onto urllib.request if aiohttp is not available,
   but performance will take a serious hit.)

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -630,10 +630,18 @@ class ManifestGenerator(contextlib.AbstractContextManager):
                                           only_arches=only_arches)
 
     def add_data_source(self, data: Union[str, bytes], destination: Path) -> None:
-        # Note that safe is empty so that slashes are escaped, to work around
-        # https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/194
-        quoted = urllib.parse.quote(data, safe='')
-        source = {'type': 'file', 'url': 'data:' + quoted}
+        if isinstance(data, bytes):
+            source = {
+                'type': 'inline',
+                'contents': base64.b64encode(data).decode('ascii'),
+                'base64': True,
+            }
+        else:
+            assert isinstance(data, str)
+            source = {
+                'type': 'inline', 
+                'contents': data,
+            }
         self._add_source_with_destination(source, destination, is_dir=False)
 
     def add_git_source(self,

--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1422,29 +1422,8 @@ class NpmModuleProvider(ModuleProvider):
             self.gen.add_command(f'FLATPAK_BUILDER_BUILDDIR=$PWD {patch_all_dest}')
 
         if self.index_entries:
-            # (ab-)use a "script" module to generate the index.
-            parents: Set[str] = set()
-
-            for path in self.index_entries:
-                for parent in map(str, path.relative_to(self.cacache_dir).parents):
-                    if parent != '.':
-                        parents.add(parent)
-
-            index_commands: List[str] = []
-            index_commands.append('import os')
-            index_commands.append(f'os.chdir({str(self.cacache_dir)!r})')
-
-            for parent in sorted(parents, key=len):
-                index_commands.append(f'os.makedirs({parent!r}, exist_ok=True)')
-
             for path, entry in self.index_entries.items():
-                path = path.relative_to(self.cacache_dir)
-                index_commands.append(f'with open({str(path)!r}, "w") as fp:')
-                index_commands.append(f'    fp.write({entry!r})')
-
-            script_dest = self.gen.data_root / 'generate-index.py'
-            self.gen.add_script_source(index_commands, script_dest)
-            self.gen.add_command(f'python3 {script_dest}')
+                self.gen.add_data_source(entry, path)
 
 
 class YarnLockfileProvider(LockfileProvider):


### PR DESCRIPTION
Use the recently-added `inline` type source to embed arbitrary data instead of (ab)using `script` type source to generate a python script. This way it's a bit faster, makes generated sources file a bit smaller, and makes the flatpak-node-generator code much simpler.