### PR TITLE
pip: Add x-checker-data

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -290,6 +290,12 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
                 ('type', 'file'),
                 ('url', url),
                 ('sha256', sha256)])
+            # if add x-checker-data
+            source['x-checker-data'] = {
+                'type': 'pypi',
+                'name': name}
+            if url.endswith(".whl"):
+                source['x-checker-data']['packagetype'] = 'bdist_wheel'
             is_vcs = False
         sources[name] = {'source': source, 'vcs': is_vcs}
 


### PR DESCRIPTION
Hey, I just modified the pip-generator to include metadata for the external data checker. This works fine for me (see https://github.com/flathub/com.github.jeromerobert.pdfarranger/pull/42) and hopefully further automate the maintenance of flatpaks packaging Python-based software.
I believe that this could be useful for others, let me know if you want a command line flag to selectively enable/disable it.