### PR TITLE
[doc] Add second example to go-get readme

### DIFF
--- a/go-get/README.md
+++ b/go-get/README.md
@@ -44,7 +44,7 @@ modules:
       build-args:
         - --share=network
     build-commands:
-      - "go env -w GOPATH=$PWD; go env -w GO111MODULE=off; go get -v github.com/writeas/writeas-cli/cmd/writeas"
+      - "go env -w GOPATH=$PWD; go env -w GO111MODULE=off; go get github.com/writeas/writeas-cli/cmd/writeas"
 ```
 
 2. Run flatpak-builder with `--keep-build-dirs`.

--- a/go-get/README.md
+++ b/go-get/README.md
@@ -25,6 +25,28 @@ The script does not require Go in the host system.
 }
 ```
 
+Yaml example:
+```yaml
+app-id: writeas-cli
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.golang
+command: echo "Done"
+modules:
+  - name: writeas
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/golang/bin
+      env:
+        GOBIN: /app/bin
+      build-args:
+        - --share=network
+    build-commands:
+      - "go env -w GOPATH=$PWD; go env -w GO111MODULE=off; go get -v github.com/writeas/writeas-cli/cmd/writeas"
+```
+
 2. Run flatpak-builder with `--keep-build-dirs`.
 3. Run `go-get/flatpak-go-get-generator.py <build-dir>` with build-dir pointing the the build directory in `.flatpak-builder/build`.
 4. Convert the source list to YAML if necessary.

--- a/go-get/README.md
+++ b/go-get/README.md
@@ -6,7 +6,7 @@ The script does not require Go in the host system.
 ## Usage
 1. In the manifest, give the Go module network access and set GOPATH to $PWD.
 
-  Example:
+  Example manifest module (json):
 ```json
 {
   "name": "writeas-cli",
@@ -25,7 +25,7 @@ The script does not require Go in the host system.
 }
 ```
 
-Yaml example:
+  Example manifest (yaml):
 ```yaml
 app-id: writeas-cli
 runtime: org.freedesktop.Platform
@@ -41,10 +41,11 @@ modules:
       append-path: /usr/lib/sdk/golang/bin
       env:
         GOBIN: /app/bin
+        GO111MODULE: off
       build-args:
         - --share=network
     build-commands:
-      - "go env -w GOPATH=$PWD; go env -w GO111MODULE=off; go get github.com/writeas/writeas-cli/cmd/writeas"
+      - "go env -w GOPATH=$PWD; go get github.com/writeas/writeas-cli/cmd/writeas"
 ```
 
 2. Run flatpak-builder with `--keep-build-dirs`.

--- a/go-get/README.md
+++ b/go-get/README.md
@@ -42,10 +42,11 @@ modules:
       env:
         GOBIN: /app/bin
         GO111MODULE: off
+        GOPATH: /run/build/writeas
       build-args:
         - --share=network
     build-commands:
-      - "go env -w GOPATH=$PWD; go get github.com/writeas/writeas-cli/cmd/writeas"
+      - go get github.com/writeas/writeas-cli/cmd/writeas
 ```
 
 2. Run flatpak-builder with `--keep-build-dirs`.


### PR DESCRIPTION
The examples of how to use the Flatpak Go Get Generator is currently slightly outdated.

This PR adds a second example Manifest which:

* Is written in YAML
* Shows a whole example manifest file
* Configures the GO111MODULE