### PR TITLE
node: Option to get electron binaries per headers

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -957,8 +957,8 @@ class SpecialSourceProvider:
             self.gen.add_url_source(integrity_file.url, integrity_file.integrity,
                                     electron_cache_dir / integrity_file.filename)
 
-    async def _handle_electron(self, package: Package) -> None:
-        manager = await ElectronBinaryManager.for_version(package.version)
+    async def __add_electron(self, version: str) -> None:
+        manager = await ElectronBinaryManager.for_version(version)
         self._add_electron_cache_downloads(manager, 'electron')
 
         if self.electron_ffmpeg is not None:
@@ -975,6 +975,9 @@ class SpecialSourceProvider:
                                                 only_arches=[binary.arch.flatpak])
             else:
                 assert False, self.electron_ffmpeg
+
+    async def _handle_electron(self, package: Package) -> None:
+        await self.__add_electron(package.version)
 
     def _handle_gulp_atom_electron(self, package: Package) -> None:
         # Versions after 1.22.0 use @electron/get and don't need this


### PR DESCRIPTION
Electron version in `.yarnrc`/`.npmrc` may be different from the version in lockfile. In such case, if the version from rcfile is used for packaging, build will fail, since we only have the headers, but not the binaries for matching version.
Such case was observed with VSCode; despite it seems like a human error that is fixed by now, I believe `flatpak-node-generator` should be able to handle it.

This patch adds a cli option that tells the generator to download electron binaries for each electron version discovered in rcfiles.