### PR TITLE
pip: Add Message for PyQt BaseApp

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -166,6 +166,13 @@ elif opts.packages:
 else:
     exit('Please specifiy either packages or requirements file argument')
 
+for i in packages:
+    if i["name"].lower().startswith("pyqt"):
+        print("PyQt packages are not supported by flapak-pip-generator")
+        print("However, there is a BaseApp for PyQt available, that you should use")
+        print("Visit https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp for more information")
+        sys.exit(0)
+
 with open(requirements_file, 'r') as req_file:
     use_hash = '--hash=' in req_file.read()
 


### PR DESCRIPTION
PyQt is widely used, but it is not supported by flatpak-pip-generator. There is now a [BaseApp for PyQt](https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp) for PyQt available. Instead of failing and leaving the User alone, flatpak-pip-generator will now provide a Link to the new BaseApp.

I know, that flatpak-pip-generator can also be used for other Repos than Flathub, but I think most of the Users are using it for Flathub. The others can go the the linked repo and copy the build files.