### PR TITLE
cpan: Fix ba500568 regression, escape $ character

### DIFF
--- a/cpan/flatpak-cpan-generator.pl
+++ b/cpan/flatpak-cpan-generator.pl
@@ -122,7 +122,7 @@ sub main {
       "    mod_dir=\$1",
       "    cd \$mod_dir",
       "    if [ -f 'Makefile.PL' ]; then",
-      "        perl Makefile.PL PREFIX=${FLATPAK_DEST} && make install PREFIX=${FLATPAK_DEST}",
+      "        perl Makefile.PL PREFIX=\${FLATPAK_DEST} && make install PREFIX=\${FLATPAK_DEST}",
       "    elif [ -f 'Build.PL' ]; then",
       "        perl Build.PL && ./Build && ./Build install",
       "    else",


### PR DESCRIPTION
Regression was introduced by ba5005689bac0f5bcfc8a9531da3c576260ceef2
Without escaping $ character I'm getting the following error:

> Global symbol "$FLATPAK_DEST" requires explicit package name (did you forget to declare "my $FLATPAK_DEST"?) at /app/bin/flatpak-cpan-generator.pl line 125.
> Global symbol "$FLATPAK_DEST" requires explicit package name (did you forget to declare "my $FLATPAK_DEST"?) at /app/bin/flatpak-cpan-generator.pl line 125.
> Bareword "main" not allowed while "strict subs" in use at /app/bin/flatpak-cpan-generator.pl line 140.
> Execution of /app/bin/flatpak-cpan-generator.pl aborted due to compilation errors.