### PR TITLE
dotnet: Sort sources to avoid needless changes

### DIFF
--- a/dotnet/flatpak-dotnet-generator.py
+++ b/dotnet/flatpak-dotnet-generator.py
@@ -57,7 +57,11 @@ def main():
             })
 
     with open(args.output, 'w') as fp:
-        json.dump(sources, fp, indent=4)
+        json.dump(
+            sorted(sources, key=lambda n: n.get("dest-filename")),
+            fp,
+            indent=4
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
At the moment, the sources generated by flatpak-dotnet-generator appear in an undefined order. This appears to be different each time I run the command, which means if I commit a generated sources file to a repository, it is difficult to keep track of changes that occur and commits end up being much larger than necessary. We can solve that by sorting the list of sources. Ordering by `dest-filename` seems like a reasonable scheme to me.