### PR TITLE
node: skip local file-sourced packages

### DIFF
--- a/node/flatpak-node-generator.py
+++ b/node/flatpak-node-generator.py
@@ -1449,6 +1449,10 @@ class NpmModuleProvider(ModuleProvider):
 
     async def generate_package(self, package: Package) -> None:
         self.all_lockfiles.add(package.lockfile)
+
+        if package.version.startswith('file:'):
+            return
+
         source = package.source
 
         assert not isinstance(source, ResolvedSource)


### PR DESCRIPTION
Fixes #251 

Node `file:` packages are local and should be available in-tree, so can be safely skipped by the generator.

This is a PR of the change in suggested in https://github.com/flatpak/flatpak-builder-tools/issues/251#issuecomment-998024781 (also mentioned and tested in https://github.com/flatpak/flatpak-builder-tools/pull/259#issuecomment-1055419507).

