### PR TITLE
node: Allow empty `resolved` field in lockfiles

### DIFF
--- a/node/flatpak_node_generator/package.py
+++ b/node/flatpak_node_generator/package.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Tuple, Union
 
+import abc
 import functools
 import re
 
@@ -81,9 +82,18 @@ class SemVer:
         return SemVer(major, minor, patch, prerelease)
 
 
-class ResolvedSource(NamedTuple):
-    resolved: str
+class PackageSource(abc.ABC):
+    pass
+
+
+@dataclass(frozen=True, eq=True)
+class RegistrySource(PackageSource):
     integrity: Optional[Integrity]
+
+
+@dataclass(frozen=True, eq=True)
+class ResolvedSource(RegistrySource):
+    resolved: str
 
     async def retrieve_integrity(self) -> Integrity:
         if self.integrity is not None:
@@ -95,18 +105,17 @@ class ResolvedSource(NamedTuple):
             return metadata.integrity
 
 
-class GitSource(NamedTuple):
+@dataclass(frozen=True, eq=True)
+class GitSource(PackageSource):
     original: str
     url: str
     commit: str
     from_: Optional[str]
 
 
-class LocalSource(NamedTuple):
+@dataclass(frozen=True, eq=True)
+class LocalSource(PackageSource):
     path: str
-
-
-PackageSource = Union[ResolvedSource, GitSource, LocalSource]
 
 
 class Package(NamedTuple):

--- a/node/flatpak_node_generator/providers/npm.py
+++ b/node/flatpak_node_generator/providers/npm.py
@@ -268,6 +268,11 @@ class NpmModuleProvider(ModuleProvider):
         elif isinstance(source, LocalSource):
             assert (package.lockfile.parent / source.path / 'package.json').is_file()
 
+        else:
+            raise NotImplementedError(
+                f'Unknown source type {source.__class__.__name__}'
+            )
+
     def relative_lockfile_dir(self, lockfile: Path) -> Path:
         return lockfile.parent.relative_to(self.lockfile_root)
 

--- a/node/flatpak_node_generator/providers/yarn.py
+++ b/node/flatpak_node_generator/providers/yarn.py
@@ -177,6 +177,11 @@ class YarnModuleProvider(ModuleProvider):
         elif isinstance(source, LocalSource):
             assert (package.lockfile.parent / source.path / 'package.json').is_file()
 
+        else:
+            raise NotImplementedError(
+                f'Unknown source type {source.__class__.__name__}'
+            )
+
         await self.special_source_provider.generate_special_sources(package)
 
 

--- a/node/tests/data/packages/missing-resolved-npm/package-lock.v2.json
+++ b/node/tests/data/packages/missing-resolved-npm/package-lock.v2.json
@@ -1,0 +1,28 @@
+{
+  "name": "@flatpak-node-generator-tests/missing-resolved-npm",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@flatpak-node-generator-tests/missing-resolved-npm",
+      "version": "1.0.0",
+      "dependencies": {
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "dependencies": {
+		"word-wrap": {
+			"version": "1.2.3",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+		}
+  }
+}

--- a/node/tests/data/packages/missing-resolved-npm/package.json
+++ b/node/tests/data/packages/missing-resolved-npm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@flatpak-node-generator-tests/missing-resolved-npm",
+  "version": "1.0.0",
+  "dependencies": {
+		"word-wrap": "^1.2.3"
+  }
+}

--- a/node/tests/test_providers.py
+++ b/node/tests/test_providers.py
@@ -90,6 +90,33 @@ async def test_local_link(
     assert hello_txt.read_text() == 'Hello!'
 
 
+async def test_missing_resolved_field(
+    flatpak_builder: FlatpakBuilder,
+    npm_provider_factory_spec: ProviderFactorySpec,
+) -> None:
+    # Only test on lockfile v2.
+    node_version = 16
+
+    with ManifestGenerator() as gen:
+        await npm_provider_factory_spec.generate_modules(
+            'missing-resolved-npm', gen, node_version
+        )
+
+    flatpak_builder.build(
+        sources=gen.ordered_sources(),
+        commands=[
+            npm_provider_factory_spec.install_command,
+            f"""node -e 'require("word-wrap")'""",
+        ],
+        use_node=node_version,
+    )
+
+    word_wrap_package_json = (
+        flatpak_builder.module_dir / 'node_modules' / 'word-wrap' / 'package.json'
+    )
+    assert word_wrap_package_json.exists()
+
+
 async def test_special_electron(
     flatpak_builder: FlatpakBuilder,
     provider_factory_spec: ProviderFactorySpec,


### PR DESCRIPTION
We don't use the `resolved` value anywhere in the npm codepath, so it seems safe to make the field optional.
Renamed `ResolvedSource` to `RegistrySource` because objects of the former class without an actual `resolved` value don't feel right.

Fixes #295
Supersedes #241