### PR TITLE
node: Support url as dependency

### DIFF
--- a/node/flatpak_node_generator/package.py
+++ b/node/flatpak_node_generator/package.py
@@ -87,12 +87,12 @@ class PackageSource(abc.ABC):
 
 
 @dataclass(frozen=True, eq=True)
-class RegistrySource(PackageSource):
+class PackageFileSource(PackageSource):
     integrity: Optional[Integrity]
 
 
 @dataclass(frozen=True, eq=True)
-class ResolvedSource(RegistrySource):
+class PackageURLSource(PackageFileSource):
     resolved: str
 
     async def retrieve_integrity(self) -> Integrity:
@@ -103,6 +103,16 @@ class ResolvedSource(RegistrySource):
             assert url is not None, 'registry source has no resolved URL'
             metadata = await RemoteUrlMetadata.get(url, cachable=True)
             return metadata.integrity
+
+
+@dataclass(frozen=True, eq=True)
+class RegistrySource(PackageFileSource):
+    pass
+
+
+@dataclass(frozen=True, eq=True)
+class ResolvedSource(RegistrySource, PackageURLSource):
+    pass
 
 
 @dataclass(frozen=True, eq=True)

--- a/node/flatpak_node_generator/providers/npm.py
+++ b/node/flatpak_node_generator/providers/npm.py
@@ -18,6 +18,7 @@ import re
 import shlex
 import textwrap
 import types
+import urllib.parse
 
 from ..integrity import Integrity
 from ..manifest import ManifestGenerator
@@ -59,6 +60,7 @@ class NpmLockfileProvider(LockfileProvider):
                 continue
 
             version: str = info['version']
+            version_url = urllib.parse.urlparse(version)
             alias_match = self._ALIAS_RE.match(version)
             if alias_match is not None:
                 name, version = alias_match.groups()
@@ -72,8 +74,8 @@ class NpmLockfileProvider(LockfileProvider):
                     from_ = from_[match.end('prefix') :]
 
                 source = self.parse_git_source(version, from_)
-            elif version.startswith('file:'):
-                source = LocalSource(path=version[len('file:') :])
+            elif version_url.scheme == 'file':
+                source = LocalSource(path=version_url.path)
             else:
                 integrity = Integrity.parse(info['integrity'])
                 if 'resolved' in info:

--- a/node/tests/data/packages/url-as-dep/package-lock.v1.json
+++ b/node/tests/data/packages/url-as-dep/package-lock.v1.json
@@ -1,0 +1,12 @@
+{
+  "name": "@flatpak-node-generator-tests/url-as-dep",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "word-wrap": {
+      "version": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    }
+  }
+}

--- a/node/tests/data/packages/url-as-dep/package-lock.v2.json
+++ b/node/tests/data/packages/url-as-dep/package-lock.v2.json
@@ -1,0 +1,30 @@
+{
+  "name": "@flatpak-node-generator-tests/url-as-dep",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@flatpak-node-generator-tests/url-as-dep",
+      "version": "1.0.0",
+      "dependencies": {
+        "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "dependencies": {
+    "word-wrap": {
+      "version": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    }
+  }
+}

--- a/node/tests/data/packages/url-as-dep/package.json
+++ b/node/tests/data/packages/url-as-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@flatpak-node-generator-tests/url-as-dep",
+  "version": "1.0.0",
+  "dependencies": {
+    "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
+  }
+}

--- a/node/tests/test_providers.py
+++ b/node/tests/test_providers.py
@@ -117,6 +117,31 @@ async def test_missing_resolved_field(
     assert word_wrap_package_json.exists()
 
 
+async def test_url_as_dep(
+    flatpak_builder: FlatpakBuilder,
+    npm_provider_factory_spec: ProviderFactorySpec,
+    node_version: int,
+) -> None:
+    with ManifestGenerator() as gen:
+        await npm_provider_factory_spec.generate_modules(
+            'url-as-dep', gen, node_version
+        )
+
+    flatpak_builder.build(
+        sources=gen.ordered_sources(),
+        commands=[
+            npm_provider_factory_spec.install_command,
+            f"""node -e 'require("word-wrap")'""",
+        ],
+        use_node=node_version,
+    )
+
+    word_wrap_package_json = (
+        flatpak_builder.module_dir / 'node_modules' / 'word-wrap' / 'package.json'
+    )
+    assert word_wrap_package_json.exists()
+
+
 async def test_special_electron(
     flatpak_builder: FlatpakBuilder,
     provider_factory_spec: ProviderFactorySpec,


### PR DESCRIPTION
"[URL as dependency](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#urls-as-dependencies)" is the term used by NPM documentation; in fact, it refers to direct package URLs in the `version` field.

Should fix #145, and probably fix #301