### PR TITLE
pip: Add comment to YAML output

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -452,6 +452,7 @@ with open(output_filename, 'w') as output:
 
         OrderedDumper.add_representer(OrderedDict, dict_representer)
 
+        output.write("# Generated with flatpak-pip-generator " + " ".join(sys.argv[1:]) + "\n")
         yaml.dump(pypi_module, output, Dumper=OrderedDumper)
     else:
         output.write(json.dumps(pypi_module, indent=4))


### PR DESCRIPTION
This PR adds a comment to the YAML output of flatpak-pip-generator, that shows what command was used to create the file.