### PR TITLE
node: Improve live progress output (and other small tweaks)

### DIFF
--- a/node/flatpak_node_generator/main.py
+++ b/node/flatpak_node_generator/main.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 
 from .cache import Cache, FilesystemBasedCache
 from .manifest import ManifestGenerator
@@ -187,6 +188,8 @@ async def _async_main() -> None:
     else:
         assert False, args.type
 
+    start_time = time.monotonic()
+
     print('Reading packages from lockfiles...')
     packages: Set[Package] = set()
     rcfile_node_headers: Set[NodeHeaders] = set()
@@ -246,6 +249,8 @@ async def _async_main() -> None:
             )
             gen.add_command(f'bash {gen.data_root / script_name}')
 
+    elapsed = round(time.monotonic() - start_time, 1)
+
     if args.split:
         i = 0
         for i, part in enumerate(gen.split_sources()):
@@ -254,7 +259,7 @@ async def _async_main() -> None:
             with open(output, 'w') as fp:
                 json.dump(part, fp, indent=ManifestGenerator.JSON_INDENT)
 
-        print(f'Wrote {gen.source_count} to {i + 1} file(s).')
+        print(f'Wrote {gen.source_count} to {i + 1} file(s) in {elapsed} second(s).')
     else:
         with open(args.output, 'w') as fp:
             json.dump(
@@ -270,7 +275,7 @@ async def _async_main() -> None:
                 )
                 print('  (Pass -s to enable splitting.)')
 
-        print(f'Wrote {gen.source_count} source(s).')
+        print(f'Wrote {gen.source_count} source(s) in {elapsed} second(s).')
 
 
 def main() -> None:

--- a/node/flatpak_node_generator/main.py
+++ b/node/flatpak_node_generator/main.py
@@ -1,12 +1,16 @@
 from pathlib import Path
-from typing import Iterator, List, Set
+from typing import Any, ContextManager, Iterator, List, Optional, Set
 
 import argparse
 import asyncio
+import contextlib
 import json
 import os
 import sys
 import time
+
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
 
 from .cache import Cache, FilesystemBasedCache
 from .manifest import ManifestGenerator
@@ -18,6 +22,8 @@ from .providers.npm import NpmLockfileProvider, NpmModuleProvider, NpmProviderFa
 from .providers.special import SpecialSourceProvider
 from .providers.yarn import YarnProviderFactory
 from .requests import Requests, StubRequests
+
+_CONSOLE_REFRESH_PER_SECOND = 12.5
 
 
 def _scan_for_lockfiles(base: Path, patterns: List[str]) -> Iterator[Path]:
@@ -52,6 +58,11 @@ async def _async_main() -> None:
         '--recursive-pattern',
         action='append',
         help='Given -r, restrict files to those matching the given pattern.',
+    )
+    parser.add_argument(
+        '--no-live-progress',
+        action='store_true',
+        help='Disable live progress output',
     )
     parser.add_argument(
         '--registry',
@@ -136,12 +147,19 @@ async def _async_main() -> None:
         dest='xdg_layout',
         help="Don't use the XDG layout for caches",
     )
-    # Internal option, useful for testing.
+    # Internal options, useful for testing.
     parser.add_argument('--stub-requests', action='store_true', help=argparse.SUPPRESS)
+    parser.add_argument(
+        '--traceback-on-interrupt',
+        action='store_true',
+        help=argparse.SUPPRESS,
+    )
 
     args = parser.parse_args()
 
     Requests.retries = args.retries
+
+    console = Console() if not args.no_live_progress and sys.stdout.isatty else None
 
     if args.type == 'yarn' and (args.no_devel or args.no_autopatch):
         sys.exit('--no-devel and --no-autopatch do not apply to Yarn.')
@@ -223,16 +241,45 @@ async def _async_main() -> None:
         )
         special = SpecialSourceProvider(gen, options)
 
-        with provider_factory.create_module_provider(gen, special) as module_provider:
-            with GeneratorProgress(
+        live: ContextManager[Any]
+        if console is not None:
+            requests_renderable = Requests.instance.get_renderable(console)
+            generator_renderable: Optional[RenderableType] = None
+
+            def get_renderable() -> RenderableType:
+                if generator_renderable is not None:
+                    return Group(
+                        requests_renderable,
+                        generator_renderable,
+                    )
+                else:
+                    return requests_renderable
+
+            live = Live(
+                get_renderable=get_renderable,
+                refresh_per_second=_CONSOLE_REFRESH_PER_SECOND,
+                console=console,
+            )
+        else:
+            live = contextlib.nullcontext()
+
+        with live:
+            with provider_factory.create_module_provider(
+                gen, special
+            ) as module_provider, GeneratorProgress(
                 packages,
                 module_provider,
-                args.max_parallel,
+                max_parallel=args.max_parallel,
+                traceback_on_interrupt=args.traceback_on_interrupt,
             ) as progress:
+                if console is not None:
+                    generator_renderable = progress.get_renderable(console)
+
                 await progress.run()
-        for headers in rcfile_node_headers:
-            print(f'Generating headers {headers.runtime} @ {headers.target}')
-            await special.generate_node_headers(headers)
+
+            for headers in rcfile_node_headers:
+                print(f'Generating headers {headers.runtime} @ {headers.target}...')
+                await special.generate_node_headers(headers)
 
         if args.xdg_layout:
             script_name = 'setup_sdk_node_headers.sh'

--- a/node/poetry.lock
+++ b/node/poetry.lock
@@ -104,7 +104,7 @@ flake8 = ">=3.8,<5.0.0"
 type = "git"
 url = "https://github.com/grantjenks/blue"
 reference = "HEAD"
-resolved_reference = "d818dd6417fb1985dba31be9aa16e85f0d814801"
+resolved_reference = "0e9f225963754cbc29449d9d220ac89b1026b0bc"
 
 [[package]]
 name = "charset-normalizer"
@@ -136,6 +136,17 @@ description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "commonmark"
+version = "0.9.1"
+description = "Python parser for the CommonMark Markdown spec"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "execnet"
@@ -361,6 +372,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "Pygments"
+version = "2.13.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+plugins = ["importlib-metadata"]
+
+[[package]]
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -460,6 +482,22 @@ setproctitle = ["setproctitle"]
 testing = ["filelock"]
 
 [[package]]
+name = "rich"
+version = "12.6.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "main"
+optional = false
+python-versions = ">=3.6.3,<4.0.0"
+
+[package.dependencies]
+commonmark = ">=0.9.0,<0.10.0"
+pygments = ">=2.6.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -525,7 +563,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "179bc4857ff39cc5e6eeb8e367ce5f42688bc0d884e07717bfed13b24bbc42a5"
+content-hash = "5e1ec7ea533641ba6417a8de7b4267b68ec12d0b9642edd3689f102f8f3d0aaa"
 
 [metadata.files]
 aiohttp = [
@@ -670,6 +708,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+commonmark = [
+    {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
+    {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
@@ -928,6 +970,10 @@ pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
+Pygments = [
+    {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
+    {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
+]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
@@ -956,6 +1002,10 @@ pytest-httpserver = [
 pytest-xdist = [
     {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},
     {file = "pytest_xdist-2.5.0-py3-none-any.whl", hash = "sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65"},
+]
+rich = [
+    {file = "rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e"},
+    {file = "rich-12.6.0.tar.gz", hash = "sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/node/pyproject.toml
+++ b/node/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Ryan Gonzalez <ryan.gonzalez@collabora.com>", "Filippe LeMarchand <g
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = "^3.8.1"
+rich = "^12.6.0"
 
 [tool.poetry.dev-dependencies]
 blue = {git = "https://github.com/grantjenks/blue"}


### PR DESCRIPTION
Second commit message has the basic summary:

> This upgrades the progress output quite a bit:
> 
> - There's a pretty animation at the start of the line!
> - Instead of printing the last package interacted with (which made no
>  sense), show as many of the currently-processing packages as can fit
>  on a single line.
> - Show live download progress for large downloads, so any that are
>   holding up generation don't result in appears to be a hang.
> 
> In addition, this adds a hidden CLI flag, --traceback-on-interrupt, that
> prints a full traceback from every active package coroutine on Ctrl-C,
> which was useful while debugging this (and probably will be in the
> future!)
> 

Live demo (with a weirdly low framerate, *but it actually looks smooth live*, not sure why it was being weird here):

[Screencast from 08-26-2022 05:59:29 PM.webm](https://user-images.githubusercontent.com/1690697/187001473-3ef06323-9205-45bf-91f2-7ab647fb8468.webm)

This may or may not have taken like, 6 hours to figure out. (Terminals are hard.)