### PR TITLE
pip: Add support for pyproject.toml

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -199,7 +199,12 @@ elif opts.pyproject_file:
     pyproject_file = os.path.expanduser(opts.pyproject_file)
     with open(pyproject_file, "rb") as f:
         pyproject_data = toml_load(f)
-    dependencies = pyproject_data.get("project", {}).get("dependencies", [])
+    is_poetry = pyproject_data.get('tool', {}).get('poetry') is not None
+    if is_poetry:
+        dependencies = pyproject_data.get('tool', {}).get('poetry', {}).get('dependencies', {})
+        dependencies.pop('python', None)
+    else:
+        dependencies = pyproject_data.get("project", {}).get("dependencies", [])
     packages = list(requirements.parse('\n'.join(dependencies)))
     with tempfile.NamedTemporaryFile('w', delete=False, prefix='requirements.') as req_file:
         req_file.write('\n'.join(dependencies))

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -29,6 +29,8 @@ parser.add_argument('--cleanup', choices=['scripts', 'all'],
                     help='Select what to clean up after build')
 parser.add_argument('--requirements-file', '-r',
                     help='Specify requirements.txt file')
+parser.add_argument('--pyproject-file',
+                    help='Specify pyproject.toml file')
 parser.add_argument('--build-only', action='store_const',
                     dest='cleanup', const='all',
                     help='Clean up all files after build')
@@ -59,6 +61,18 @@ parser.add_argument('--ignore-errors', action='store_true',
 parser.add_argument('--ignore-pkg', nargs='*',
                     help='Ignore a package when generating the manifest. Can only be used with a requirements file')
 opts = parser.parse_args()
+
+if opts.requirements_file and opts.pyproject_file:
+    exit('Can\'t use both requirements and pyproject files at the same time')
+
+if opts.pyproject_file:
+    try:
+        from tomllib import load as toml_load
+    except ModuleNotFoundError:
+        try:
+            from tomli import load as toml_load
+        except ModuleNotFoundError:
+            exit('tomli modules is not installed. Run "pip install tomli"')
 
 if opts.yaml:
     try:
@@ -180,6 +194,16 @@ if opts.requirements_file:
     except FileNotFoundError as err:
         print(err)
         sys.exit(1)
+
+elif opts.pyproject_file:
+    pyproject_file = os.path.expanduser(opts.pyproject_file)
+    with open(pyproject_file, "rb") as f:
+        pyproject_data = toml_load(f)
+    dependencies = pyproject_data.get("project", {}).get("dependencies", [])
+    packages = list(requirements.parse('\n'.join(dependencies)))
+    with tempfile.NamedTemporaryFile('w', delete=False, prefix='requirements.') as req_file:
+        req_file.write('\n'.join(dependencies))
+        requirements_file_output = req_file.name
 
 elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))

--- a/pip/readme.md
+++ b/pip/readme.md
@@ -44,7 +44,8 @@ You can use that in your manifest like
 * `--build-isolation`: Enable build isolation with pip (recommended but not always work).
 * `--cleanup=(scripts|all)`: Add `cleanup` to the manifest. This is used when the packages installed are only used at build time.
 * `--build-only`: Alias to `--cleanup=all`.
-* `--requirements-file=`, `-r`: Reads the list of packages from `requirements.txt` file.
+* `--requirements-file=`, `-r`: Reads the list of packages from `requirements.txt` file. Mutually exclusive with `--pyproject-file`.
+* `--pyproject-file=`: Reads the list of packages from `pyproject.toml` file. Mutually exclusive with `--requirements-file` or `r`.
 * `--ignore-pkg=`: Ignore a specific package name in a requirements-file, otherwise ignored.
 * `--checker-data`: This adds `x-checker-data` to modules so you will be notified when new releases happen. See [flatpak-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) for more details.
 * `--runtime=`: Runs `pip` inside of a specific Flatpak runtime instead of on your host. Highly recommended for reproducability and portability. Examples would be `org.freedesktop.Sdk//22.08` or `org.gnome.Sdk/aarch64/43`.


### PR DESCRIPTION
This PR adds support for reading [dependencies from a ypproject.toml](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#declaring-project-metadata). On Python versions older than 3.11, you need to install tomli to use this feature.