### PR TITLE
pip: Add --ignore-installed option

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -38,6 +38,13 @@ parser.add_argument('--build-isolation', action='store_true',
                         'Mostly useful on pip that does\'t '
                         'support the feature.'
                     ))
+parser.add_argument('--ignore-installed',
+                    type=lambda s: s.split(','),
+                    default='',
+                    help='Comma-separated list of package names for which pip '
+                    'should ignore already installed packages. Useful when '
+                    'the package is installed in the SDK but not in the '
+                    'runtime.')
 parser.add_argument('--checker-data', action='store_true',
                     help='Include x-checker-data in output for the "Flatpak External Data Checker"')
 parser.add_argument('--output', '-o',
@@ -411,6 +418,8 @@ for package in packages:
         '--prefix=${FLATPAK_DEST}',
         '"{}"'.format(name_for_pip)
     ]
+    if package.name in opts.ignore_installed:
+        pip_command.append('--ignore-installed')
     if not opts.build_isolation:
         pip_command.append('--no-build-isolation')
 

--- a/pip/readme.md
+++ b/pip/readme.md
@@ -46,5 +46,6 @@ You can use that in your manifest like
 * `--requirements-file=`, `-r`: Reads the list of packages from `requirements.txt` file.
 * `--checker-data`: This adds `x-checker-data` to modules so you will be notified when new releases happen. See [flatpak-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) for more details.
 * `--runtime=`: Runs `pip` inside of a specific Flatpak runtime instead of on your host. Highly recommended for reproducability and portability. Examples would be `org.freedesktop.Sdk//22.08` or `org.gnome.Sdk/aarch64/43`.
+* `--ignore-installed=`: Comma-separated list of package names for which pip should ignore already installed packages. Useful when the package is installed in the SDK but not in the runtime.
 * `--output=`: Sets an output file.
 * `--yaml`: Outputs a YAML file.


### PR DESCRIPTION
This option takes a comma-separated list of package names. It adds the `--ignore-installed` option to the pip command for these packages.

This is necessary for packages that are installed in the Sdk but then not part of the runtime (e.g. [lxml][1]).

[1]: https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/380