### PR TITLE
node: skip errors on optional dependencies

### DIFF
--- a/node/flatpak_node_generator/providers/npm.py
+++ b/node/flatpak_node_generator/providers/npm.py
@@ -134,6 +134,9 @@ class NpmLockfileProvider(LockfileProvider):
                         'Git sources in lockfile v2 format are not supported yet'
                         f' (package {install_path} in {lockfile})'
                     )
+            elif info.get('optional'):
+                # Optional dependencies can be skipped
+                continue
             else:
                 raise NotImplementedError(
                     f"Don't know how to handle package {install_path} in {lockfile}"


### PR DESCRIPTION
e.g. In https://raw.githubusercontent.com/lensapp/lens/master/package-lock.json

```json
    "node_modules/npm/node_modules/@colors/colors": {
      "version": "1.5.0",
      "inBundle": true,
      "license": "MIT",
      "optional": true,
      "engines": {
        "node": ">=0.1.90"
      }
    },
```