### PR TITLE
pip: propagate error when downloading packages

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -53,6 +53,8 @@ parser.add_argument('--runtime',
                     help='Specify a flatpak to run pip inside of a sandbox, ensures python version compatibility')
 parser.add_argument('--yaml', action='store_true',
                     help='Use YAML as output format instead of JSON')
+parser.add_argument('--ignore-errors', action='store_true',
+                    help='Ignore errors when downloading packages')
 opts = parser.parse_args()
 
 if opts.yaml:
@@ -251,6 +253,9 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
     except subprocess.CalledProcessError:
         print('Failed to download')
         print('Please fix the module manually in the generated file')
+        if not opts.ignore_errors:
+            print('Ignore the error by passing --ignore-errors')
+            raise
 
     if not opts.requirements_file:
         try:

--- a/pip/readme.md
+++ b/pip/readme.md
@@ -46,6 +46,7 @@ You can use that in your manifest like
 * `--requirements-file=`, `-r`: Reads the list of packages from `requirements.txt` file.
 * `--checker-data`: This adds `x-checker-data` to modules so you will be notified when new releases happen. See [flatpak-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) for more details.
 * `--runtime=`: Runs `pip` inside of a specific Flatpak runtime instead of on your host. Highly recommended for reproducability and portability. Examples would be `org.freedesktop.Sdk//22.08` or `org.gnome.Sdk/aarch64/43`.
+* `--ignore-errors=`: Allow the generation of empty or otherwise broken files when downloading packages fails.
 * `--ignore-installed=`: Comma-separated list of package names for which pip should ignore already installed packages. Useful when the package is installed in the SDK but not in the runtime.
 * `--output=`: Sets an output file.
 * `--yaml`: Outputs a YAML file.


### PR DESCRIPTION
If pip fails to download, the generated sources file is empty and, arguably, useless. Instead of silently generating an empty file, the error is propagated now.

The root cause appears to be a bug in pip.

https://github.com/flatpak/flatpak-builder-tools/issues/265