### PR TITLE
Allow ignoring package in flatpak-pip-generator

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -55,6 +55,8 @@ parser.add_argument('--yaml', action='store_true',
                     help='Use YAML as output format instead of JSON')
 parser.add_argument('--ignore-errors', action='store_true',
                     help='Ignore errors when downloading packages')
+parser.add_argument('--ignore-pkg', nargs='*',
+                    help='Ignore a package when generating the manifest. Can only be used with a requirements file')
 opts = parser.parse_args()
 
 if opts.yaml:
@@ -158,12 +160,20 @@ def fprint(string: str) -> None:
 
 packages = []
 if opts.requirements_file:
-    requirements_file = os.path.expanduser(opts.requirements_file)
+    requirements_file_input = os.path.expanduser(opts.requirements_file)
     try:
-        with open(requirements_file, 'r') as req_file:
+        with open(requirements_file_input, 'r') as req_file:
             reqs = parse_continuation_lines(req_file)
             reqs_as_str = '\n'.join([r.split('--hash')[0] for r in reqs])
-            packages = list(requirements.parse(reqs_as_str))
+            reqs_list = reqs_as_str.splitlines()
+            if opts.ignore_pkg:
+                reqs_new = '\n'.join(i for i in reqs_list if i not in opts.ignore_pkg)
+            else:
+                reqs_new = reqs_as_str
+            packages = list(requirements.parse(reqs_new))
+            with tempfile.NamedTemporaryFile('w', delete=False, prefix='requirements.') as req_file:
+                req_file.write(reqs_new)
+                requirements_file_output = req_file.name
     except FileNotFoundError:
         pass
 
@@ -171,7 +181,7 @@ elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))
     with tempfile.NamedTemporaryFile('w', delete=False, prefix='requirements.') as req_file:
         req_file.write('\n'.join(opts.packages))
-        requirements_file = req_file.name
+        requirements_file_output = req_file.name
 else:
     exit('Please specifiy either packages or requirements file argument')
 
@@ -182,7 +192,7 @@ for i in packages:
         print("Visit https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp for more information")
         sys.exit(0)
 
-with open(requirements_file, 'r') as req_file:
+with open(requirements_file_output, 'r') as req_file:
     use_hash = '--hash=' in req_file.read()
 
 python_version = '2' if opts.python2 else '3'
@@ -202,9 +212,8 @@ if opts.runtime:
         opts.runtime
     ]
     if opts.requirements_file:
-        requirements_file = os.path.expanduser(opts.requirements_file)
-        if os.path.exists(requirements_file):
-            prefix = os.path.realpath(requirements_file)
+        if os.path.exists(requirements_file_output):
+            prefix = os.path.realpath(requirements_file_output)
             flag = '--filesystem={}'.format(prefix)
             flatpak_cmd.insert(1,flag)
 else:
@@ -243,7 +252,7 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
         '--dest',
         tempdir,
         '-r',
-        requirements_file
+        requirements_file_output
     ]
     if use_hash:
         pip_download.append('--require-hashes')
@@ -260,9 +269,8 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
             print('Ignore the error by passing --ignore-errors')
             raise
 
-    if not opts.requirements_file:
         try:
-            os.remove(requirements_file)
+            os.remove(requirements_file_output)
         except FileNotFoundError:
             pass
 

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -177,8 +177,9 @@ if opts.requirements_file:
             with tempfile.NamedTemporaryFile('w', delete=False, prefix='requirements.') as req_file:
                 req_file.write(reqs_new)
                 requirements_file_output = req_file.name
-    except FileNotFoundError:
-        pass
+    except FileNotFoundError as err:
+        print(err)
+        sys.exit(1)
 
 elif opts.packages:
     packages = list(requirements.parse('\n'.join(opts.packages)))

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -6,6 +6,7 @@ import argparse
 import json
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -165,7 +166,9 @@ if opts.requirements_file:
         with open(requirements_file_input, 'r') as req_file:
             reqs = parse_continuation_lines(req_file)
             reqs_as_str = '\n'.join([r.split('--hash')[0] for r in reqs])
-            reqs_list = reqs_as_str.splitlines()
+            reqs_list_raw = reqs_as_str.splitlines()
+            py_version_regex = re.compile(r';.*python_version .+$') # Remove when pip-generator can handle python_version
+            reqs_list = [py_version_regex.sub('', p) for p in reqs_list_raw]
             if opts.ignore_pkg:
                 reqs_new = '\n'.join(i for i in reqs_list if i not in opts.ignore_pkg)
             else:

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -186,7 +186,10 @@ elif opts.packages:
         req_file.write('\n'.join(opts.packages))
         requirements_file_output = req_file.name
 else:
-    exit('Please specifiy either packages or requirements file argument')
+    if not len(sys.argv) > 1:
+        exit('Please specifiy either packages or requirements file argument')
+    else:
+        exit('This option can only be used with requirements file')
 
 for i in packages:
     if i["name"].lower().startswith("pyqt"):

--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -268,7 +268,9 @@ with tempfile.TemporaryDirectory(prefix=tempdir_prefix) as tempdir:
     print('Running: "{}"'.format(cmd))
     try:
         subprocess.run(pip_download, check=True)
+        os.remove(requirements_file_output)
     except subprocess.CalledProcessError:
+        os.remove(requirements_file_output)
         print('Failed to download')
         print('Please fix the module manually in the generated file')
         if not opts.ignore_errors:


### PR DESCRIPTION
See commit message for explanation.

This is useful when someone wants to ignore a problematic package specified in `requirements.txt`. It can be due to multiple reasons that comes to mind: 

- the package is not available for current python version as a result downloading errors out even if other packages in the list are fine eg.

```
dataclasses==0.8
Sample2
```

- The package doesn't have a sdist tarball on pypi, and we want to manually add it to the manifest to build from source. Eg.

```
pyside6
Sample2
```

- Bugs like https://github.com/flatpak/flatpak-builder-tools/issues/328, that prevents producing a manifest altogether

(alternate take on https://github.com/flatpak/flatpak-builder-tools/pull/217, but a bit complicated)

Usage:

```
./flatpak-pip-generator --ignore-pkg <pkg1> <pkg2> -r reqs.txt
```
