### PR TITLE
CI: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -27,7 +27,7 @@ jobs:
           - '1.1.13'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure git
         run: |
           git config --global user.name 'github-actions[bot]'


### PR DESCRIPTION
This PR bumps the `actions/checkout` version from v3 (Node 16) to v4 (Node 20) as Node 16 is reaching eol soon.
Ref. https://nodejs.org/en/blog/announcements/nodejs16-eol