### PR TITLE
Update node-gyp installVersion

### DIFF
--- a/node/flatpak_node_generator/main.py
+++ b/node/flatpak_node_generator/main.py
@@ -240,7 +240,7 @@ async def _async_main() -> None:
                     'nodedir=$(dirname "$(dirname "$(which node)")")',
                     f'mkdir -p "{node_gyp_dir}/$version"',
                     f'ln -s "$nodedir/include" "{node_gyp_dir}/$version/include"',
-                    f'echo 9 > "{node_gyp_dir}/$version/installVersion"',
+                    f'echo 11 > "{node_gyp_dir}/$version/installVersion"',
                 ],
                 destination=gen.data_root / script_name,
             )


### PR DESCRIPTION
Latest version is 11, see https://github.com/nodejs/node-gyp/blob/main/package.json#L15

A lower version makes node-gyp remove the headers and force a new download

After a quick glance I think the changes for versions 10 and 11 affect the windows platform and error detection during tarball extraction so I think there's no other change required here.