### PR TITLE
cargo: Fix KeyError for workspaces that don't contain all sections

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -134,9 +134,10 @@ class _GitPackage(NamedTuple):
             for key, value in section.items():
                 if not isinstance(value, dict):
                     continue
-                if not value.get('workspace'):
+                try:
+                    package[section_key][key] = self.workspace[section_key][key]
+                except KeyError:
                     continue
-                package[section_key][key] = self.workspace[section_key][key]
         return package
 
 


### PR DESCRIPTION
I stumbled upon this when trying to build gtk-rs-core.

https://github.com/gtk-rs/gtk-rs-core/blob/master/Cargo.toml

The workspace itself doesn't have a dev-dependencies key, so it will throw a KeyError.

```
  File "flatpak-cargo-generator.py", line 139, in normalized
    package[section_key][key] = self.workspace[section_key][key]
                                ~~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'dev-dependencies'
```