### PR TITLE
Fix cargo workspace replacement for git deps

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -124,6 +124,10 @@ def update_workspace_keys(pkg, workspace):
                 if 'dependencies' in target:
                     update_workspace_keys(target['dependencies'], workspace['dependencies'])
             continue;
+        # dev-dependencies should reference root dependencies table from workspace
+        elif key == 'dev-dependencies':
+            update_workspace_keys(item, workspace['dependencies'])
+            continue;
 
         if not key in workspace:
             continue;


### PR DESCRIPTION
Current implementation assumes all workspace dependencies in workspace crates are single entry maps of
`<dep>.workspace = true` and overrides the `<dep>` value from the workspace

This fails if the workspace crate includes other keys for the `<dep>`, such as `optional = true` or
`features = []`, since those are dropped.

The current implementation also failed to properly recurse to capture `target.cfg(..).dependencies`.

This has been updated to properly fix the above

This fix was used to successfully generate sources for and build https://github.com/flathub/org.squidowl.halloy/pull/5