### PR TITLE
Skip directory sources in Poetry lockfiles

### DIFF
--- a/poetry/flatpak-poetry-generator.py
+++ b/poetry/flatpak-poetry-generator.py
@@ -86,6 +86,10 @@ def get_module_sources(parsed_lockfile: dict, include_devel: bool = True) -> lis
                                     match = hash_re.search(package_files[num]["hash"])
                                     if match:
                                         hashes.append(match.group(2))
+                    package_source = package.get("source")
+                    if package_source and package_source["type"] == "directory":
+                        print(f'Skipping download url and hash extraction for {package["name"]}, source type is directory')
+                        continue
                     url, hash = get_pypi_source(
                         package["name"], package["version"], hashes
                     )


### PR DESCRIPTION
Directory sources, or "path dependencies" as the Poetry documentation[1] calls them, are by definition not available on PyPi. As such, there is no point in attempting to download these since there is no way to tell where the source could be acquired from the lockfile alone.

 [1]: https://python-poetry.org/docs/dependency-specification/#path-dependencies