### PR TITLE
Add Swift Package Manager (SPM) support

### DIFF
--- a/spm/README.md
+++ b/spm/README.md
@@ -31,8 +31,7 @@ The tool creates a `generated-sources.json` and a `setup-offline.sh` file in the
     "build-commands": [
         "./setup-offline.sh",
         "swift build -c release --static-swift-stdlib",
-        "mkdir /app/bin",
-        "cp .build/release/quickstart /app/bin"
+        "install -Dm755 .build/release/quickstart /app/bin/quickstart"
     ]
 }
 ```

--- a/spm/README.md
+++ b/spm/README.md
@@ -29,7 +29,6 @@ The tool creates a `generated-sources.json` and a `setup-offline.sh` file in the
         "generated-sources.json"
     ],
     "build-commands": [
-        "chmod +x ./setup-offline.sh ./setup-offline.sh",
         "./setup-offline.sh",
         "swift build -c release --static-swift-stdlib",
         "rm -r -f /app/bin",

--- a/spm/README.md
+++ b/spm/README.md
@@ -1,0 +1,43 @@
+# flatpak-spm-generator
+
+Tool to automatically generate `flatpak-builder` manifest JSON from a Swift package.
+
+## Requirements
+
+Swift is required to execute the script. It is not only written as a Swift script, but also uses Swift to get information about the dependencies of the package.
+
+## Usage
+
+The first step is to convert the dependencies declared in the `Package.swift` file as well as the dependencies of those dependencies into a format flatpak-builder can understand,
+and generate a script that makes SPM use the offline dependencies.
+```
+swift flatpak-spm-generator.swift ./quickstart ./quickstart
+```
+
+The first path is the directory containing the Swift package, and the second path is the directory containing the Flatpak manifest file.
+
+The tool creates a `generated-sources.json` and a `setup-offline.sh` file in the directory of the Flatpak manifest. Here is a sample module of a manifest showing how to use those generated files.
+```json
+{
+    "name": "quickstart",
+    "buildsystem": "simple",
+    "sources": [
+        {
+            "type": "dir",
+            "path": "."
+        },
+        "generated-sources.json"
+    ],
+    "build-commands": [
+        "chmod +x ./setup-offline.sh ./setup-offline.sh",
+        "./setup-offline.sh",
+        "swift build -c release --static-swift-stdlib",
+        "rm -r -f /app/bin",
+        "mkdir /app/bin",
+        "cp .build/release/quickstart /app/bin"
+    ]
+}
+```
+
+See the quickstart project for a complete example.
+

--- a/spm/README.md
+++ b/spm/README.md
@@ -31,7 +31,6 @@ The tool creates a `generated-sources.json` and a `setup-offline.sh` file in the
     "build-commands": [
         "./setup-offline.sh",
         "swift build -c release --static-swift-stdlib",
-        "rm -r -f /app/bin",
         "mkdir /app/bin",
         "cp .build/release/quickstart /app/bin"
     ]

--- a/spm/flatpak-spm-generator.swift
+++ b/spm/flatpak-spm-generator.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+let arguments = CommandLine.arguments
+
+// The path to the directory containing the SPM manifest.
+let path = arguments.count > 1 ? arguments[1] : "."
+// The path to the directory containing the Flatpak manifest.
+let pathToManifest = arguments.count > 2 ? arguments[2] : "."
+
+// Build the Swift package to get a complete list of dependencies under "{path}/.build/workspace-state.json".
+let task = Process()
+task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+task.arguments = ["swift", "build", "-c", "release", "--package-path", path]
+try task.run()
+task.waitUntilExit()
+
+// Parse the dependencies in the workspace state file.
+let workspaceStatePath = path + "/.build/workspace-state.json"
+guard let workspaceStateData = FileManager.default.contents(atPath: workspaceStatePath) else {
+    fatalError("The workspace state file expected at \(workspaceStatePath) could not be found.")
+}
+let workspaceState = try JSONDecoder().decode(WorkspaceState.self, from: workspaceStateData)
+
+// Copy the names of the folders under "{path}/.build/repositories".
+let repositoriesPath = path + "/.build/repositories"
+let repositoriesContent = try FileManager.default.contentsOfDirectory(atPath: repositoriesPath)
+
+// Generate the JSON file with the sources and the shell script for tweaks.
+var content = """
+[
+"""
+var shellContent = """
+#!/usr/bin/env bash
+mkdir .build/repositories
+cd .build/repositories
+"""
+
+for dependency in workspaceState.object.dependencies {
+    let subpath = dependency.subpath
+    content.append("""
+
+        {
+            "type": "git",
+            "url": "\(dependency.packageRef.location)",
+            "disable-shallow-clone": true,
+            "commit": "\(dependency.state.checkoutState.revision)",
+            "dest": ".build/checkouts/\(subpath)"
+        },
+    """)
+    if let folder = repositoriesContent.first(where: { $0.hasPrefix(subpath) }) {
+        shellContent.append("""
+
+        cp -r ../checkouts/\(subpath)/.git/* ./\(folder)
+        """)
+    }
+}
+content.removeLast()
+content.append("\n]")
+
+// Save the files.
+let contentData = content.data(using: .utf8)
+let shellContentData = shellContent.data(using: .utf8)
+try contentData?.write(to: .init(fileURLWithPath: "\(pathToManifest)/generated-sources.json"))
+try shellContentData?.write(to: .init(fileURLWithPath: "\(pathToManifest)/setup-offline.sh"))
+
+// Types for decoding workspace state file.
+struct Dependency: Codable {
+
+    var packageRef: PackageRef
+    var state: State
+    var subpath: String
+
+    struct PackageRef: Codable {
+
+        var location: String
+
+    }
+
+    struct State: Codable {
+
+        var checkoutState: CheckoutState
+
+    }
+
+    struct CheckoutState: Codable {
+
+        var revision: String
+
+    }
+
+}
+
+struct WorkspaceState: Codable {
+
+    var object: Object
+
+    struct Object: Codable {
+
+        var dependencies: [Dependency]
+
+    }
+
+}

--- a/spm/flatpak-spm-generator.swift
+++ b/spm/flatpak-spm-generator.swift
@@ -58,10 +58,18 @@ content.removeLast()
 content.append("\n]")
 
 // Save the files.
+let pathToSetup = "\(pathToManifest)/setup-offline.sh"
+
 let contentData = content.data(using: .utf8)
 let shellContentData = shellContent.data(using: .utf8)
 try contentData?.write(to: .init(fileURLWithPath: "\(pathToManifest)/generated-sources.json"))
-try shellContentData?.write(to: .init(fileURLWithPath: "\(pathToManifest)/setup-offline.sh"))
+try shellContentData?.write(to: .init(fileURLWithPath: pathToSetup))
+
+let executable = Process()
+executable.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+executable.arguments = ["chmod", "+x", pathToSetup]
+try executable.run()
+executable.waitUntilExit()
 
 // Types for decoding workspace state file.
 struct Dependency: Codable {

--- a/spm/quickstart/Package.swift
+++ b/spm/quickstart/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "quickstart",
+    products: [
+        .executable(
+            name: "quickstart",
+            targets: ["quickstart"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/AparokshaUI/adwaita-swift", from: "0.2.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "quickstart",
+            dependencies: [.product(name: "Adwaita", package: "adwaita-swift")]
+        )
+    ]
+)

--- a/spm/quickstart/Sources/quickstart/main.swift
+++ b/spm/quickstart/Sources/quickstart/main.swift
@@ -6,7 +6,7 @@ import Adwaita
 @main
 struct QuickStart: App {
 
-    let id = "com.flatpak.quickstart"
+    let id = "org.flatpak.quickstart"
     var app: GTUIApp!
 
     var scene: Scene {

--- a/spm/quickstart/Sources/quickstart/main.swift
+++ b/spm/quickstart/Sources/quickstart/main.swift
@@ -1,0 +1,26 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+import Adwaita
+
+@main
+struct QuickStart: App {
+
+    let id = "com.flatpak.quickstart"
+    var app: GTUIApp!
+
+    var scene: Scene {
+        Window(id: "main") { _ in
+            Text("Hello, world!")
+                .padding(50)
+                .topToolbar {
+                    HeaderBar.empty()
+                }
+        }
+        .title("Demo")
+        .resizable(false)
+        .closeShortcut()
+        .quitShortcut()
+    }
+
+}

--- a/spm/quickstart/com.flatpak.quickstart.json
+++ b/spm/quickstart/com.flatpak.quickstart.json
@@ -31,7 +31,6 @@
             "build-commands": [
                 "./setup-offline.sh",
                 "swift build -c release --static-swift-stdlib",
-                "rm -r -f /app/bin",
                 "mkdir /app/bin",
                 "cp .build/release/quickstart /app/bin"
             ]

--- a/spm/quickstart/com.flatpak.quickstart.json
+++ b/spm/quickstart/com.flatpak.quickstart.json
@@ -31,8 +31,7 @@
             "build-commands": [
                 "./setup-offline.sh",
                 "swift build -c release --static-swift-stdlib",
-                "mkdir /app/bin",
-                "cp .build/release/quickstart /app/bin"
+                "install -Dm755 .build/release/quickstart /app/bin/quickstart"
             ]
         }
     ]

--- a/spm/quickstart/com.flatpak.quickstart.json
+++ b/spm/quickstart/com.flatpak.quickstart.json
@@ -1,0 +1,41 @@
+{
+    "app-id": "com.flatpak.quickstart",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "45",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.swift5"
+    ],
+    "command": "quickstart",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/swift5/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/swift5/lib"
+    },
+    "modules": [
+        {
+            "name": "quickstart",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "."
+                },
+                "generated-sources.json"
+            ],
+            "build-commands": [
+                "chmod +x ./setup-offline.sh ./setup-offline.sh",
+                "./setup-offline.sh",
+                "swift build -c release --static-swift-stdlib",
+                "rm -r -f /app/bin",
+                "mkdir /app/bin",
+                "cp .build/release/quickstart /app/bin"
+            ]
+        }
+    ]
+}

--- a/spm/quickstart/com.flatpak.quickstart.json
+++ b/spm/quickstart/com.flatpak.quickstart.json
@@ -29,7 +29,6 @@
                 "generated-sources.json"
             ],
             "build-commands": [
-                "chmod +x ./setup-offline.sh ./setup-offline.sh",
                 "./setup-offline.sh",
                 "swift build -c release --static-swift-stdlib",
                 "rm -r -f /app/bin",

--- a/spm/quickstart/org.flatpak.quickstart.json
+++ b/spm/quickstart/org.flatpak.quickstart.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "com.flatpak.quickstart",
+    "app-id": "org.flatpak.quickstart",
     "runtime": "org.gnome.Platform",
     "runtime-version": "45",
     "sdk": "org.gnome.Sdk",


### PR DESCRIPTION
Hi!

This PR adds support for [SPM](https://www.swift.org/documentation/package-manager/) (e.g. useful in combination with the [Swift 5 SDK Extension](https://github.com/flathub/flathub/pull/4935)). It contains a script for generating the necessary  files, a README and a sample Swift package.