### PR TITLE
spm: Fixes

### DIFF
--- a/spm/flatpak-spm-generator.swift
+++ b/spm/flatpak-spm-generator.swift
@@ -47,7 +47,7 @@ for dependency in workspaceState.object.dependencies {
             "dest": ".build/checkouts/\(subpath)"
         },
     """)
-    if let folder = repositoriesContent.first(where: { $0.hasPrefix(subpath) }) {
+    if let folder = repositoriesContent.first(where: { $0.hasPrefix(subpath + "-") }) {
         shellContent.append("""
 
         mkdir ./\(folder)

--- a/spm/flatpak-spm-generator.swift
+++ b/spm/flatpak-spm-generator.swift
@@ -50,11 +50,18 @@ for dependency in workspaceState.object.dependencies {
     if let folder = repositoriesContent.first(where: { $0.hasPrefix(subpath) }) {
         shellContent.append("""
 
+        mkdir ./\(folder)
         cp -r ../checkouts/\(subpath)/.git/* ./\(folder)
         """)
     }
 }
-content.removeLast()
+content.append("""
+
+        {
+             "type": "file",
+             "path": "setup-offline.sh"
+        }
+""")
 content.append("\n]")
 
 // Save the files.


### PR DESCRIPTION
spm: Add the script to the generate json
 
Create the folders in the setup script.

The rationale is to only have to add `generated-sources.json` to the manifest, so we need to list the `setup-offline.sh` too.

The `setup-offline.sh` need to create the destination directories otherwise it fails.

spm: Fix the generation when a package name is the substring of another
    
Example: `SwiftPangoCairo` and `SwiftPango`. The latter would be skipped.


(trying to build https://github.com/flathub/co.luoja.Telyn from source)