### PR TITLE
Fix KeyError when cargo git deps omit workspace.dependencies

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -122,14 +122,14 @@ def update_workspace_keys(pkg, workspace):
         if key == 'target':
             for target in item.values():
                 if 'dependencies' in target:
-                    update_workspace_keys(target['dependencies'], workspace['dependencies'])
+                    update_workspace_keys(target['dependencies'], workspace.get('dependencies', None))
             continue;
         # dev-dependencies should reference root dependencies table from workspace
         elif key == 'dev-dependencies':
-            update_workspace_keys(item, workspace['dependencies'])
+            update_workspace_keys(item, workspace.get('dependencies', None))
             continue;
 
-        if not key in workspace:
+        if not workspace or not key in workspace:
             continue;
 
         workspace_item = workspace[key]


### PR DESCRIPTION
Fixes a crash when git dependencies are in a workspace that declares no workspace-level dependencies. [For example](https://github.com/warp-tech/russh/blob/1d7dab8db178455bc0d3ce1be8faeebc978e45d3/Cargo.toml#L1-L2):

```toml
package.name = "uses-russh"
dependencies.russh.git = "https://github.com/warp-tech/russh"
```

`cargo generate-lockfile && flatpak-cargo-generator.py Cargo.lock`:

```
INFO:root:Loading packages from https://github.com/warp-tech/russh
INFO:root:Adding package russh from https://github.com/warp-tech/russh
INFO:root:Adding package russh-cryptovec from https://github.com/warp-tech/russh
INFO:root:Adding package russh-keys from https://github.com/warp-tech/russh
Traceback (most recent call last):
  File "/tmp/flatpak-builder-tools/cargo/flatpak-cargo-generator.py", line 470, in <module>
    main()
  File "/tmp/flatpak-builder-tools/cargo/flatpak-cargo-generator.py", line 463, in main
    generated_sources = asyncio.run(generate_sources(load_toml(args.cargo_lock),
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/tmp/flatpak-builder-tools/cargo/flatpak-cargo-generator.py", line 417, in generate_sources
    for pkg in await asyncio.gather(*pkg_coros):
  File "/tmp/flatpak-builder-tools/cargo/flatpak-cargo-generator.py", line 367, in get_package_sources
    return await get_git_package_sources(package, git_repos)
  File "/tmp/flatpak-builder-tools/cargo/flatpak-cargo-generator.py", line 337, in get_git_package_sources
    'contents': toml.dumps(git_pkg.normalized),
  File "/tmp/flatpak-builder-tools/cargo/flatpak-cargo-generator.py", line 160, in normalized
    update_workspace_keys(package, self.workspace)
  File "/tmp/flatpak-builder-tools/cargo/flatpak-cargo-generator.py", line 129, in update_workspace_keys
    update_workspace_keys(item, workspace['dependencies'])
KeyError: 'dependencies'
```