### PR TITLE
Simplify flatpak-cargo-generator.py dependency install with Poetry

### DIFF
--- a/cargo/README.md
+++ b/cargo/README.md
@@ -2,18 +2,21 @@
 
 Tool to automatically generate `flatpak-builder` manifest json from a `Cargo.lock`.
 
-## Requirements:
+## Requirements
 
-Python 3.8+ with following modules:
+Poetry users can run `poetry install` and skip this.
 
+Otherwise install Python 3.8+ with these modules:
 - toml
 - aiohttp
 
 Generated manifests are supported by flatpak-builder 1.2.x or newer.
 
-## Usage:
+## Usage
 
-The first step is to convert the locked dependencies by Cargo into a format flatpak-builder can understand
+Poetry users: first activate your virtualenv by running `poetry shell`.
+
+Convert the locked dependencies by Cargo into a format flatpak-builder can understand:
 ```
 python3 ./flatpak-cargo-generator.py ./quickstart/Cargo.lock -o cargo-sources.json
 ```

--- a/cargo/pyproject.toml
+++ b/cargo/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = ">=3.8"
+aiohttp = "^3.9.5"
+toml = "^0.10.2"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I like to give tools such as `flatpak-cargo-generator.py` a dedicated virtualenv with the necessary dependencies, and Poetry was an easy way to handle the logistics behind the scenes.