### PR TITLE
node: Fix path-based local package detection

### DIFF
--- a/node/flatpak_node_generator/providers/npm.py
+++ b/node/flatpak_node_generator/providers/npm.py
@@ -110,7 +110,7 @@ class NpmLockfileProvider(LockfileProvider):
             source: PackageSource
             package_json_path = lockfile.parent / install_path / 'package.json'
             if (
-                'node_modules' not in package_json_path.parents
+                'node_modules' not in install_path.split('/')
                 and package_json_path.exists()
             ):
                 source = LocalSource(path=install_path)


### PR DESCRIPTION
_(Please correct me if I'm wrong)_

The conditions here, if I understand correctly, are to detect whether a package is from a local source, with these two clues:
- none of its parent directories (up to the lockfile) is called `node_modules`, and
- it has a `package.json`

The first one, however, has two issues:
- `Path.parents` yields `PosixPath` objects, not strings, so the test `'node_modules' in ...` never succeeds.
- `Path.parents` yields all logical ancestors of a path (see https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parents), which is probably not what we want here.

This change fixes these issues.

I tested this by running `flatpak-node-generator -r npm package-lock.json` under [Insomnia](https://github.com/Kong/insomnia) source tree.
- Before, it only emits about 1300 entries, which is not sufficient for an offline install (for example, missing `supports-color@8.1.0`).
- After this change it can emit almost all entries, but it fails later when dealing with playwright, which is another problem.