### PR TITLE
pip: add setuptools to the missing modules error message

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -19,7 +19,7 @@ from typing import Dict
 try:
     import requirements
 except ImportError:
-    exit('Requirements modules is not installed. Run "pip install requirements-parser"')
+    exit('Required python modules are not installed. Run "pip install setuptools requirements-parser"')
 
 parser = argparse.ArgumentParser()
 parser.add_argument('packages', nargs='*')


### PR DESCRIPTION
Installing requirements-parser was not enough for `import requirements` to work on my system. I also needed to install setuptools to avoid the following error:

```
Python 3.12.3 (main, Apr 17 2024, 00:00:00) [GCC 14.0.1 20240411 (Red Hat 14.0.1-0)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requirements
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/home/mwglen/.local/lib/python3.12/site-packages/requirements/__init__.py", line 19, in <module>
    from .parser import parse
  File "/var/home/mwglen/.local/lib/python3.12/site-packages/requirements/parser.py", line 23, in <module>
    from .requirement import Requirement
  File "/var/home/mwglen/.local/lib/python3.12/site-packages/requirements/requirement.py", line 24, in <module>
    from pkg_resources import Requirement as Req
ModuleNotFoundError: No module named 'pkg_resources'
```