### PR TITLE
dotnet: Process multiple projects in parallel

### DIFF
--- a/dotnet/flatpak-dotnet-generator.py
+++ b/dotnet/flatpak-dotnet-generator.py
@@ -14,9 +14,9 @@ import concurrent.futures
 
 def main():
     # Bump this to latest freedesktop runtime version.
-    freedesktop_default = '22.08'
+    freedesktop_default = '24.08'
     # Bump this to an LTS dotnet version.
-    dotnet_default = '6'
+    dotnet_default = '8'
 
     parser = argparse.ArgumentParser()
     parser.add_argument('output', help='The output JSON sources file')


### PR DESCRIPTION
This expands on https://github.com/flatpak/flatpak-builder-tools/pull/206 by running `dotnet restore` operations for multiple csproj files in parallel. 

This can greatly speed up the processing time for larger dotnet projects.

Let me know if you'd like any changes :smile: 