### PR TITLE
Fix some typos in the cargo flatpak manifest

### DIFF
--- a/cargo/README.md
+++ b/cargo/README.md
@@ -29,7 +29,7 @@ The output file should be added to the manifest like
     "build-commands": [
         "cargo --offline fetch --manifest-path Cargo.toml --verbose",
         "cargo --offline build --release --verbose",
-        "install -Dm755 ./target/debug/quickstart -t /app/bin/"
+        "install -Dm755 ./target/release/quickstart -t /app/bin/"
     ],
     "sources": [
         {
@@ -45,3 +45,4 @@ Make sure to override CARGO_HOME env variable to point it to `/run/build/$module
 
 
 For a complete example see the quickstart project.
+

--- a/cargo/quickstart/com.flatpak.quickstart.json
+++ b/cargo/quickstart/com.flatpak.quickstart.json
@@ -25,7 +25,7 @@
         "build-commands": [
             "cargo --offline fetch --manifest-path Cargo.toml --verbose",
             "cargo --offline build --release --verbose",
-            "install -Dm755 ./target/debug/qucikstart -t /app/bin/"
+            "install -Dm755 ./target/release/quickstart -t /app/bin/"
         ],
         "sources": [{
                 "type": "dir",


### PR DESCRIPTION
Hi !

This commit fixes 2 things in the flatpak manifest:

* In the `build-commands`, cargo build the app with `--release`. But the folder referenced is `/debug/` instead of `/release/`
* In the file `com.flatpak.quickstart.json`, there is a small typo: `qucikstart` instead of `quickstart`