### PR TITLE
pip: don't consider system_packages for python2

### DIFF
--- a/pip/flatpak-pip-generator
+++ b/pip/flatpak-pip-generator
@@ -377,7 +377,7 @@ for package in packages:
         print('Warning: skipping invalid requirement specification {} because it is missing a name'.format(package.line), file=sys.stderr)
         print('Append #egg=<pkgname> to the end of the requirement line to fix', file=sys.stderr)
         continue
-    elif package.name.casefold() in system_packages:
+    elif not opts.python2 and package.name.casefold() in system_packages:
         print(f"{package.name} is in system_packages. Skipping.")
         continue
 


### PR DESCRIPTION
The freedesktop runtime only provides python3, so this will incorrectly skip important packages when run in python2 mode that are actually needed.