### PR TITLE
cargo: Use force checkout if git sources in cache differ

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -133,7 +133,15 @@ def fetch_git_repo(git_url: str, commit: str) -> str:
     head = rev_parse_proc.stdout.decode().strip()
     if head[:COMMIT_LEN] != commit[:COMMIT_LEN]:
         subprocess.run(["git", "fetch", "origin", commit], cwd=clone_dir, check=True)
-        subprocess.run(["git", "checkout", commit], cwd=clone_dir, check=True)
+        try:
+            subprocess.run(["git", "checkout", commit], cwd=clone_dir, check=True)
+        except subprocess.CalledProcessError:
+            logging.info(
+                "Checking out commit %s failed for %s. Trying to force checkout the requested commit",
+                commit,
+                git_url,
+            )
+            subprocess.run(["git", "checkout", "-f", commit], cwd=clone_dir, check=True)
 
     # Get the submodules as they might contain dependencies. This is a noop if
     # there are no submodules in the repository


### PR DESCRIPTION
Fixes https://github.com/flatpak/flatpak-builder-tools/issues/414