### PR TITLE
Setup cargo config in cargo generator README

### DIFF
--- a/cargo/README.md
+++ b/cargo/README.md
@@ -28,6 +28,7 @@ The output file should be added to the manifest like
     "name": "quickstart",
     "buildsystem": "simple",
     "build-commands": [
+        "install -Dm644 cargo/config .cargo/config.toml",
         "cargo --offline fetch --manifest-path Cargo.toml --verbose",
         "cargo --offline build --release --verbose",
         "install -Dm755 ./target/release/quickstart -t /app/bin/"


### PR DESCRIPTION
Without this step the configuration file is at the wrong place, and cargo won't use the vendored sources.