### PR TITLE
Add end-of-file newline for flatpak-pip-generator

### DIFF
--- a/pip/flatpak-pip-generator.py
+++ b/pip/flatpak-pip-generator.py
@@ -605,7 +605,7 @@ with open(output_filename, "w") as output:
         )
         yaml.dump(pypi_module, output, Dumper=OrderedDumper)
     else:
-        output.write(json.dumps(pypi_module, indent=4))
+        output.write(json.dumps(pypi_module, indent=4) + "\n")
     print(f"Output saved to {output_filename}")
 
 if len(unresolved_dependencies_errors) != 0:


### PR DESCRIPTION
Currently, when generating source files for Python modules using JSON, the file does not end with a newline.
According to [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206), this should not be the case.
Additionally, manually editing the files afterward will most likely add a newline, thereby cluttering the Git diffs.