### PR TITLE
gradle: Fix c-ares initialisation error

### DIFF
--- a/gradle/README.md
+++ b/gradle/README.md
@@ -46,3 +46,9 @@ the manual commands above to ship in your Flatpak repository, so you can run:
 $ flatpak run --command=bash --share=network --filesystem=`pwd` -d org.freedesktop.Sdk//21.08 ./script.sh
 $ flatpak-gradle-generator.py gradle-log.txt gradle-dependencies.json
 ```
+
+If necessary, you can modify the level of output from the script by setting the
+`LOGLEVEL` environment variable to a [supported log level](https://docs.python.org/3/library/logging.html#logging-levels):
+```
+$ LOGLEVEL=debug flatpak-gradle-generator.py gradle-log.txt gradle-dependencies.json
+```

--- a/gradle/flatpak-gradle-generator.py
+++ b/gradle/flatpak-gradle-generator.py
@@ -8,6 +8,7 @@ import json
 import hashlib
 import logging
 import re
+import os
 
 arches = {
         'linux-x86_64': 'x86_64',
@@ -63,6 +64,9 @@ def flatpak_arch_to_gradle_arch(arch):
     return rev_arches[arch]
 
 def main():
+    logging.basicConfig(
+        level=os.environ.get('LOGLEVEL', 'WARNING').upper()
+    )
     parser = argparse.ArgumentParser()
     parser.add_argument('input', help='The gradle log file')
     parser.add_argument('output', help='The output JSON sources file')


### PR DESCRIPTION
Fixed the build at https://github.com/flathub/org.ghidra_sre.Ghidra/pull/104 using this

With a sufficiently large number of URLs to process, the script would
fail with:
```
pycares.AresError: Failed to initialize c-ares channel
```

which usually means that process resources are exhausted.

Use a single HTTP session for aiohttp, as recommended in the
aiohttp docs:
> Don’t create a session per request. [...]
> [M]aking a session for every request is a very bad idea.
> A session contains a connection pool inside.

See https://docs.aiohttp.org/en/stable/client_quickstart.html

Reproduce using:
```
$ LOGLEVEL=info ./flatpak-gradle-generator.py gradle-log.txt ../gradle-dependencies.json --destdir dependencies/flatRepo --arches x86_64,aarch64
```

It will fail with the original code, and work with the fixed one.

[gradle-log.txt](https://github.com/user-attachments/files/20924597/gradle-log.txt)

