### PR TITLE
SPM: Add support for custom file suffixes

### DIFF
--- a/spm/README.md
+++ b/spm/README.md
@@ -38,3 +38,11 @@ The tool creates a `generated-sources.json` and a `setup-offline.sh` file in the
 
 See the quickstart project for a complete example.
 
+### Suffix
+
+Optionally, add a third argument with a suffix for the file names. This can be helpful if multiple Swift packages are present.
+```
+swift flatpak-spm-generator.swift ./quickstart ./quickstart quickstart
+```
+
+The tool then creates a `generated-sources-<suffix>.json` and a `setup-offline-<suffix>.sh` file in the directory of the Flatpak manifest.

--- a/spm/flatpak-spm-generator.swift
+++ b/spm/flatpak-spm-generator.swift
@@ -6,6 +6,12 @@ let arguments = CommandLine.arguments
 let path = arguments.count > 1 ? arguments[1] : "."
 // The path to the directory containing the Flatpak manifest.
 let pathToManifest = arguments.count > 2 ? arguments[2] : "."
+/// An optional suffix.
+var suffix = arguments.count > 3 ? arguments[3] : ""
+
+if !suffix.isEmpty {
+    suffix = "-" + suffix
+}
 
 // Build the Swift package to get a complete list of dependencies under "{path}/.build/workspace-state.json".
 let task = Process()
@@ -60,17 +66,17 @@ content.append("""
 
     {
          "type": "file",
-         "path": "setup-offline.sh"
+         "path": "setup-offline\(suffix).sh"
     }
 """)
 content.append("\n]")
 
 // Save the files.
-let pathToSetup = "\(pathToManifest)/setup-offline.sh"
+let pathToSetup = "\(pathToManifest)/setup-offline\(suffix).sh"
 
 let contentData = content.data(using: .utf8)
 let shellContentData = shellContent.data(using: .utf8)
-try contentData?.write(to: .init(fileURLWithPath: "\(pathToManifest)/generated-sources.json"))
+try contentData?.write(to: .init(fileURLWithPath: "\(pathToManifest)/generated-sources\(suffix).json"))
 try shellContentData?.write(to: .init(fileURLWithPath: pathToSetup))
 
 let executable = Process()


### PR DESCRIPTION
This facilitates the generation if multiple Swift packages are present (e.g. in the [Swift 6 SDK Extension](https://github.com/flathub/org.freedesktop.Sdk.Extension.swift6/blob/branch/24.08/generated-sources-swiftlint.json)).