### PR TITLE
Deno: Inline required fields from meta.json

### DIFF
--- a/deno/deno.json
+++ b/deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatpak-contrib/flatpak-deno-generator",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "exports": "./src/main.ts",
   "license": "MIT"
 }

--- a/deno/src/main.ts
+++ b/deno/src/main.ts
@@ -75,14 +75,19 @@ export interface FlatpakData {
 export async function jsrPkgToFlatpakData(pkg: Pkg): Promise<FlatpakData[]> {
   const flatpkData: FlatpakData[] = [];
   const metaUrl = `https://jsr.io/${pkg.module}/meta.json`;
-  const metaText = await fetch(
+  const metaJson = await fetch(
     metaUrl,
-  ).then((r) => r.text());
+  ).then((r) => r.json());
 
+  // "meta.json" file is a stateful file, thats why we inline what we need
   flatpkData.push({
-    type: "file",
-    url: metaUrl,
-    sha256: await sha256(metaText),
+    type: "inline",
+    contents: JSON.stringify({
+      scope: metaJson.scope,
+      name: metaJson.name,
+      latest: metaJson.latest,
+      versions: {},
+    }),
     dest: `vendor/jsr.io/${pkg.module}`,
     "dest-filename": "meta.json",
   });


### PR DESCRIPTION
because meta.json is satefull