### PR TITLE
flatpak-cargo-builder: unwrap tomldoc

### DIFF
--- a/cargo/flatpak-cargo-generator.py
+++ b/cargo/flatpak-cargo-generator.py
@@ -120,7 +120,7 @@ _TomlType = Dict[str, Any]
 
 def load_toml(tomlfile: str = "Cargo.lock") -> _TomlType:
     with open(tomlfile, "r", encoding="utf-8") as f:
-        toml_data = tomlkit.parse(f.read())
+        toml_data = tomlkit.parse(f.read()).unwrap()
     return toml_data
 
 


### PR DESCRIPTION
this was generating invalid hashes because tomlkit.load and tomlkit.parse return TomlDocument instead of dict.