### PR TITLE
node: Added -S option to set the split size

### DIFF
--- a/node/flatpak_node_generator/main.py
+++ b/node/flatpak_node_generator/main.py
@@ -96,6 +96,14 @@ async def _async_main() -> None:
         help='Split the sources file to fit onto GitHub.',
     )
     parser.add_argument(
+        '-S',
+        '--split-size',
+        type=int,
+        default=49 * 1000,  # GITHUB has 49MB limit.
+        dest='split_size',
+        help='If splitting the sources file, split at this size in KB. Default is 49000KB.',
+    )
+    parser.add_argument(
         '--node-chromedriver-from-electron',
         help='Use the ChromeDriver version associated with the given '
         'Electron version for node-chromedriver',
@@ -206,6 +214,7 @@ async def _async_main() -> None:
     print(f'{len(packages)} packages read.')
 
     gen = ManifestGenerator()
+    gen.split_size = args.split_size * 1000
     with gen:
         options = SpecialSourceProvider.Options(
             node_chromedriver_from_electron=args.node_chromedriver_from_electron
@@ -267,7 +276,7 @@ async def _async_main() -> None:
                 indent=ManifestGenerator.JSON_INDENT,
             )
 
-            if fp.tell() >= ManifestGenerator.MAX_GITHUB_SIZE:
+            if fp.tell() >= gen.split_size:
                 print(
                     'WARNING: generated-sources.json is too large for GitHub.',
                     file=sys.stderr,

--- a/node/flatpak_node_generator/manifest.py
+++ b/node/flatpak_node_generator/manifest.py
@@ -19,7 +19,6 @@ from .integrity import Integrity
 
 
 class ManifestGenerator(ContextManager['ManifestGenerator']):
-    MAX_GITHUB_SIZE = 49 * 1000 * 1000
     JSON_INDENT = 4
 
     def __init__(self) -> None:
@@ -27,6 +26,7 @@ class ManifestGenerator(ContextManager['ManifestGenerator']):
         # That way, we ensure uniqueness.
         self._sources: Set[Tuple[Tuple[str, Any], ...]] = set()
         self._commands: List[str] = []
+        self.split_size = 49 * 1000 * 1000
 
     def __exit__(
         self,
@@ -66,7 +66,7 @@ class ManifestGenerator(ContextManager['ManifestGenerator']):
             # opening brackets.
             source_json = json.dumps([source], indent=ManifestGenerator.JSON_INDENT)
             source_json_len = len('\n'.join(source_json.splitlines()[1:-1]))
-            if current_size + source_json_len >= ManifestGenerator.MAX_GITHUB_SIZE:
+            if current_size + source_json_len >= self.split_size:
                 yield current
                 current = []
                 current_size = BASE_CURRENT_SIZE


### PR DESCRIPTION
This is useful outside of github, or if the limit ever change.

(for example I'm working with a setup that limit files to 500KB)

Default is unchanged (ie if you don't pass -S)