### PR TITLE
nuget: add flag to inject only-arches data into generated files

### DIFF
--- a/dotnet/flatpak-dotnet-generator.py
+++ b/dotnet/flatpak-dotnet-generator.py
@@ -46,7 +46,7 @@ def main() -> None:
         default="nuget-sources",
     )
     parser.add_argument(
-        "--only-arches", help="limit the outout to this flatpak arch", default=None
+        "--only-arches", help="Limit the source to this Flatpak arch", default=None
     )
     parser.add_argument(
         "--dotnet-args",


### PR DESCRIPTION
This PR is the result of some changes I made locally to the nuget generator to allow me to inject `only-arches` values ([see the module sources docs](https://docs.flatpak.org/en/latest/module-sources.html)) into the generated output.

The reason for this is because I am consistently encountering issues where generating the module sources files for arm machines while using my x86 machine. I have yet to figure out exactly why ~2 dependencies are getting skipped when done from arm (even with the `linux-arm64` runtime configured using existing args). The easiest solution so far is to just regenerate the file on an arm machine and use this new flag to essentially conditionally load it into the main app manifest.