### PR TITLE
node: Fix generator ripgrep binary mappings and add missing arches

### DIFF
--- a/node/flatpak_node_generator/providers/special.py
+++ b/node/flatpak_node_generator/providers/special.py
@@ -303,11 +303,22 @@ class SpecialSourceProvider:
             return match.group(1)
 
         tag = await get_ripgrep_tag(package.version)
+
+        # vscode-ripgrep switched from -gnu to -musl for aarch64 in v1.13.0
+        use_gnu_aarch64 = SemVer.parse(package.version) < SemVer.parse('1.13.0')
+
         ripgrep_arch_map = {
             'x86_64': 'x86_64-unknown-linux-musl',
             'i386': 'i686-unknown-linux-musl',
             'arm': 'arm-unknown-linux-gnueabihf',
-            'aarch64': 'aarch64-unknown-linux-gnu',
+            'aarch64': (
+                'aarch64-unknown-linux-gnu'
+                if use_gnu_aarch64
+                else 'aarch64-unknown-linux-musl'
+            ),
+            'ppc64': 'powerpc64le-unknown-linux-gnu',
+            'riscv64': 'riscv64gc-unknown-linux-gnu',
+            's390x': 's390x-unknown-linux-gnu',
         }
         destdir = self.gen.data_root / 'tmp' / f'vscode-ripgrep-cache-{package.version}'
         for arch, ripgrep_arch in ripgrep_arch_map.items():


### PR DESCRIPTION
The @vscode/ripgrep package postinstall script expects specific binary variants for each architecture. This patch:

1. Fixes aarch64 to use musl variant instead of gnu
   - Both variants exist, but postinstall expects musl
   - Aligns with x86_64 and i386 (which also use musl)

2. Adds missing architecture mappings for ppc64, riscv64, and s390x
   - These architectures are supported by @vscode/ripgrep
   - Uses gnu variants (only available option for these arches)

Current code causes the postinstall script to fail to find the cached binary on aarch64 and attempt to download from GitHub, which fails in offline build environments (RPM builds, air-gapped systems, etc).

The mappings now match exactly what the postinstall script expects: https://github.com/microsoft/vscode-ripgrep/blob/main/lib/postinstall.js#L38-L47

Assisted-by: Claude Code