### PR TITLE
pip: Fix dependency list generation on systems where $TMPDIR is set

### DIFF
--- a/pip/flatpak-pip-generator.py
+++ b/pip/flatpak-pip-generator.py
@@ -541,7 +541,7 @@ if opts.runtime:
         get_flatpak_runtime_scope(opts.runtime),
         "--devel",
         "--share=network",
-        "--filesystem=/tmp",
+        f"--filesystem={tempfile.gettempdir()}",
         f"--command={pip_executable}",
         "run",
         opts.runtime,


### PR DESCRIPTION
Otherwise the list of sources in the generated JSON file is empty (with no explanation).