### PR TITLE
node: Fix playwright handler for new versions

### DIFF
--- a/node/flatpak_node_generator/providers/special.py
+++ b/node/flatpak_node_generator/providers/special.py
@@ -352,41 +352,55 @@ class SpecialSourceProvider:
             revision = int(browser['revision'])
 
             if name == 'chromium':
+                version = browser['browserVersion']
                 # Revision number scheme was changed from Chromium revisions to incrementing
                 # integers above 1000; now it's same as for other browsers
                 if (
                     SemVer.parse(package.version) < SemVer.parse('1.21.0')
                     and revision < 792639
                 ):
-                    url_tp = 'https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/%d/%s'
                     dl_file = 'chrome-linux.zip'
-                else:
-                    url_tp = 'https://playwright.azureedge.net/builds/chromium/%d/%s'
+                    dl_url = f'https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/{revision}/{dl_file}'
+                elif SemVer.parse(package.version) < SemVer.parse('1.58.0'):
                     dl_file = 'chromium-linux.zip'
+                    dl_url = f'https://cdn.playwright.dev/builds/chromium/{revision}/{dl_file}'
+                else:
+                    dl_file = 'chrome-linux64.zip'
+                    dl_url = f'https://cdn.playwright.dev/builds/cft/{version}/linux64/{dl_file}'
             elif name == 'chromium-headless-shell':
-                url_tp = 'https://playwright.azureedge.net/builds/chromium/%d/%s'
-                dl_file = 'chromium-headless-shell-linux.zip'
+                version = browser['browserVersion']
+                if SemVer.parse(package.version) < SemVer.parse('1.58.0'):
+                    dl_file = 'chromium-headless-shell-linux.zip'
+                    dl_url = f'https://cdn.playwright.dev/builds/chromium/{revision}/{dl_file}'
+                else:
+                    dl_file = 'chrome-headless-shell-linux64.zip'
+                    dl_url = f'https://cdn.playwright.dev/builds/cft/{version}/linux64/{dl_file}'
             elif name == 'firefox':
-                url_tp = 'https://playwright.azureedge.net/builds/firefox/%d/%s'
                 if revision < 1140:
                     dl_file = 'firefox-linux.zip'
                 else:
                     dl_file = 'firefox-ubuntu-22.04.zip'
+                dl_url = (
+                    f'https://cdn.playwright.dev/builds/firefox/{revision}/{dl_file}'
+                )
             elif name == 'webkit':
-                url_tp = 'https://playwright.azureedge.net/builds/webkit/%d/%s'
                 if revision < 1317:
                     dl_file = 'minibrowser-gtk-wpe.zip'
                 elif revision <= 2092:
                     dl_file = 'webkit-ubuntu-20.04.zip'
                 else:
                     dl_file = 'webkit-ubuntu-24.04.zip'
+                dl_url = (
+                    f'https://cdn.playwright.dev/builds/webkit/{revision}/{dl_file}'
+                )
             elif name == 'ffmpeg':
-                url_tp = 'https://playwright.azureedge.net/builds/ffmpeg/%d/%s'
                 dl_file = 'ffmpeg-linux.zip'
+                dl_url = (
+                    f'https://cdn.playwright.dev/builds/ffmpeg/{revision}/{dl_file}'
+                )
             else:
                 raise ValueError(f'Unknown playwright browser {name}')
 
-            dl_url = url_tp % (revision, dl_file)
             metadata = await RemoteUrlMetadata.get(dl_url, cachable=True)
             destdir = (
                 self.gen.data_root / 'cache' / 'ms-playwright' / f'{name}-{revision}'


### PR DESCRIPTION
Hi! The old cdn seems to be deprecated (apparently https://github.com/microsoft/playwright/issues/38967 ) 


I was about to write an issue to ask what to do about the missing arm64 builds
> The current url seems to be https://cdn.playwright.dev/builds/cft/146.0.7680.31/linux64/chrome-headless-shell-linux64.zip which I found from https://github.com/pietdevries94/playwright-web-flake/commit/6a8be826d49dbacc939a4bb4ab3a7286aee7b223 (thanks)
> but do you know any less fragile way to keep up with these kinds of random breakages? :p
> 
> That link fetches from https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.31/linux64/chrome-linux64.zip so I looked around a little further and according to the list under https://github.com/GoogleChromeLabs/chrome-for-testing/blob/main/data/last-known-good-versions-with-downloads.json there're no arm builds for linux.  
> 
> I wanted to ask what could be done for that?

but apparently there were no arm builds previously either, I wonder if those "successful" arm builds worked at all :sweat_smile: 

Updated the old formatting as well.