### PR TITLE
pip: use universal wheels only if there are no others

### DIFF
--- a/pip/flatpak-pip-generator.py
+++ b/pip/flatpak-pip-generator.py
@@ -428,7 +428,12 @@ def resolve_package_sources(
         (f for f in get_pypi_files() if is_universal(f["filename"])),
         None,
     )
-    if pypi_universal:
+
+    # Only take a universal wheel if there are no platform-specific ones: the
+    # platform-specific ones likely contain precompiled fast-paths.  In that
+    # case we'll either want the platform-specific wheels or a source build,
+    # depending on user preference.
+    if pypi_universal and not any(is_platform_wheel(f["filename"]) for f in get_pypi_files()):
         return [make_source(pypi_universal)], []
 
     if not is_preferred:


### PR DESCRIPTION
If any wheel is universal (like py3-linux-any), we'll immediately short-circuit and take it in preference to a source package under the theory that it's probably all pure Python sourcecode in there anyway. This misses an important point, however: some packages (like websockets) have optimized arch-specific wheels with specific optimizations and also publish slower universal wheels as a fallback.  Selecting the universal wheel in this case is probably a mistake.

Modify the check so we only take the universal wheel if there's no platform-specific one.  What happens next is up to user preference: by default you'll end up building from the sdist, but you can also `--prefer-wheels` (possibly with `--wheel-arches`) to get the platform-specific wheels instead.