### PR TITLE
node: Don't require chromedriver for Electron < 1.8.5

### DIFF
--- a/node/flatpak_node_generator/electron.py
+++ b/node/flatpak_node_generator/electron.py
@@ -59,6 +59,11 @@ class ElectronBinaryManager:
             ):
                 continue
 
+            if binary == 'chromedriver' and SemVer.parse(self.version) < SemVer.parse(
+                '1.8.5'
+            ):
+                continue
+
             binary_filename = f'{binary}-v{self.version}-linux-{electron_arch}.zip'
             binary_url = self.child_url(binary_filename)
 


### PR DESCRIPTION
Before 1.8.5 the chromedriver binary was inconsistently shipped with electron releases (some had it, some didn't) and even earlier during Electron 0.24.0 etc. the filename had its own version instead of Electron's version