### PR TITLE
node: fix wrong hash algorithm

### DIFF
--- a/node/flatpak_node_generator/populate_pnpm_store.py
+++ b/node/flatpak_node_generator/populate_pnpm_store.py
@@ -141,6 +141,8 @@ def _pack_v11_store_entry(
 
     # Record with fixed entries
     result = RECORD_HEADER + b'\x40' + _msgpack_pack(store_entry_keys)
+    # This is hardcoded to use sha512 per pnpm's behavior, see @pnpm/store.cafs/index and
+    # file digest logic below
     result += _msgpack_pack('sha512')  # algo
     result += _msgpack_pack(False)  # requiresBuild
     result += files_map_bytes  # files (standard map → iterable Map in JS)

--- a/node/flatpak_node_generator/populate_pnpm_store.py
+++ b/node/flatpak_node_generator/populate_pnpm_store.py
@@ -98,7 +98,6 @@ RECORD_HEADER = b'\xd4\x72'
 
 
 def _pack_v11_store_entry(
-    algo: str,
     files: dict[str, dict[str, object]],
     manifest: dict[str, str] | None = None,
 ) -> bytes:
@@ -142,7 +141,7 @@ def _pack_v11_store_entry(
 
     # Record with fixed entries
     result = RECORD_HEADER + b'\x40' + _msgpack_pack(store_entry_keys)
-    result += _msgpack_pack(algo)  # algo
+    result += _msgpack_pack('sha512')  # algo
     result += _msgpack_pack(False)  # requiresBuild
     result += files_map_bytes  # files (standard map → iterable Map in JS)
 
@@ -295,7 +294,7 @@ def _process_tarball(
                 'version': real_pkg_version,
             }
 
-        entry_bytes = _pack_v11_store_entry(integrity_algo, v11_files, manifest)
+        entry_bytes = _pack_v11_store_entry(v11_files, manifest)
 
         # It's currently not possible to fully determine which store key pnpm will use,
         # so we insert multiple keys to ensure pnpm can find the entry it wants.

--- a/node/tests/test_populate_pnpm_store.py
+++ b/node/tests/test_populate_pnpm_store.py
@@ -476,7 +476,7 @@ def test_process_tarball_v11(tmp_path: Path) -> None:
     )
 
     integrity = Integrity(
-        'sha512', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
+        'sha256', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
     )
 
     try:
@@ -645,7 +645,7 @@ def test_pack_v11_store_entry() -> None:
         },
     }
     manifest = {'name': 'test-pkg', 'version': '1.0.0'}
-    packed = _pack_v11_store_entry('sha512', files, manifest)
+    packed = _pack_v11_store_entry(files, manifest)
 
     data = _decode_v11(packed)
     assert isinstance(data, dict)
@@ -665,7 +665,7 @@ def test_pack_v11_store_entry_no_manifest() -> None:
     files = {
         'index.js': {'checkedAt': 123, 'digest': 'hex123', 'mode': 420, 'size': 50}
     }
-    packed = _pack_v11_store_entry('sha512', files, None)
+    packed = _pack_v11_store_entry(files, None)
 
     data = _decode_v11(packed)
     assert isinstance(data, dict)


### PR DESCRIPTION
In response to https://github.com/flatpak/flatpak-builder-tools/pull/537#discussion_r3263542961 , I changed the `algo` field of entry to `integrity_algo`, which is tarball's hash algorithm, not for CAFS. It was not fully tested after the change (To be frank, I forgot why I wrote `sha512` in the first place :cry: ). For CAFS, pnpm always uses `sha512`:

https://github.com/pnpm/pnpm/blob/8695496f58edf54836d440b01a862b46eaa7f497/store/cafs/src/index.ts#L31

This PR reverts the mistake and adds the comment to avoid future confusion. It's tested in the field with an actual lockfile and pnpm ran fine without errors.