### PR TITLE
node: fix invalid YAML syntax in pnpm v11 storeDir setup

### DIFF
--- a/node/flatpak_node_generator/providers/pnpm.py
+++ b/node/flatpak_node_generator/providers/pnpm.py
@@ -292,7 +292,7 @@ class PnpmModuleProvider(ModuleProvider):
     def _add_pnpm_config(self) -> None:
         if self._store_version == 'v11':
             self.gen.add_command(
-                f'echo "storeDir=$PWD/{self.store_dir}" >> pnpm-workspace.yaml'
+                f'echo "storeDir: $PWD/{self.store_dir}" >> pnpm-workspace.yaml'
             )
         else:
             self.gen.add_command(f'echo "store-dir=$PWD/{self.store_dir}" >> .npmrc')


### PR DESCRIPTION
With `--pnpm-store-version v11`, `_add_pnpm_config()` writes `storeDir=$PWD/...` to `pnpm-workspace.yaml` which is invalid YAML, crashes pnpm:
`[ERROR] can not read a block mapping entry; a multiline key may not be an implicit key`

Fix: `=` → `: `. The else branch (`.npmrc` + `store-dir=`) is correct as-is and unchanged.

Introduced in #537. [Reference comment](https://github.com/flatpak/flatpak-builder-tools/pull/537#discussion_r3354772801)