### PR TITLE
node: Drop armv7l for electron 44+

### DIFF
--- a/node/flatpak_node_generator/electron.py
+++ b/node/flatpak_node_generator/electron.py
@@ -59,6 +59,13 @@ class ElectronBinaryManager:
             ):
                 continue
 
+            # Electron v44+ drop linux-armv7l support.
+            if (
+                SemVer.parse(self.version) >= SemVer.parse('44.0.0')
+                and electron_arch == 'armv7l'
+            ):
+                continue
+
             if binary == 'chromedriver' and SemVer.parse(self.version) < SemVer.parse(
                 '1.8.5'
             ):


### PR DESCRIPTION
Seems like this check alone should suffice but please review, the latest release dropped support for armv7l on Linux 
> Removed 32-bit builds (Windows ia32 and Linux armv7l). Electron is now published only for 64-bit (x64 and arm64) platforms. https://github.com/electron/electron/pull/52326

Fixes #549