### PR TITLE
node: Add --no-playwright-browsers flag

### DIFF
--- a/node/flatpak_node_generator/main.py
+++ b/node/flatpak_node_generator/main.py
@@ -131,6 +131,11 @@ async def _async_main() -> None:
         help='Download the electron node headers',
     )
     parser.add_argument(
+        '--no-playwright-browsers',
+        action='store_true',
+        help="Don't download the prebuilt browsers for playwright",
+    )
+    parser.add_argument(
         '--nwjs-version',
         help='Specify NW.js version (will use latest otherwise)',
     )
@@ -257,6 +262,7 @@ async def _async_main() -> None:
             electron_ffmpeg=args.electron_ffmpeg,
             electron_node_headers=args.electron_node_headers,
             node_sdk_extension=args.node_sdk_extension,
+            no_playwright_browsers=args.no_playwright_browsers,
         )
         special = SpecialSourceProvider(gen, options)
 

--- a/node/flatpak_node_generator/providers/special.py
+++ b/node/flatpak_node_generator/providers/special.py
@@ -4,6 +4,7 @@ import collections
 import itertools
 import json
 import re
+import sys
 import urllib.parse
 from pathlib import Path
 from typing import NamedTuple
@@ -29,6 +30,7 @@ class SpecialSourceProvider:
         nwjs_ffmpeg: bool
         xdg_layout: bool
         node_sdk_extension: str | None
+        no_playwright_browsers: bool = False
 
     def __init__(self, gen: ManifestGenerator, options: Options):
         self.gen = gen
@@ -40,6 +42,7 @@ class SpecialSourceProvider:
         self.nwjs_ffmpeg = options.nwjs_ffmpeg
         self.xdg_layout = options.xdg_layout
         self.node_sdk_extension = options.node_sdk_extension
+        self.no_playwright_browsers = options.no_playwright_browsers
 
     @property
     def electron_cache_dir(self) -> Path:
@@ -337,6 +340,14 @@ class SpecialSourceProvider:
             )
 
     async def _handle_playwright(self, package: Package) -> None:
+        if self.no_playwright_browsers:
+            print(
+                    f'INFO: {package.name}@{package.version}: '
+                    'skipping browser downloads (--no-playwright-browsers)',
+                    file=sys.stderr,
+            )
+            return
+
         base_url = f'https://github.com/microsoft/playwright/raw/v{package.version}/'
         if SemVer.parse(package.version) >= SemVer.parse('1.16.0'):
             browsers_json_url = base_url + 'packages/playwright-core/browsers.json'


### PR DESCRIPTION
To avoid fetching the playwright browsers in cases where we don't need them in the final flatpack sandbox.